### PR TITLE
Remove unnecessary type constraints on test helpers

### DIFF
--- a/src/FluentValidation/TestHelper/ValidatorTestExtensions.cs
+++ b/src/FluentValidation/TestHelper/ValidatorTestExtensions.cs
@@ -25,21 +25,21 @@ namespace FluentValidation.TestHelper {
 
 	public static class ValidationTestExtension {
 		public static void ShouldHaveValidationErrorFor<T, TValue>(this IValidator<T> validator,
-		                                                           Expression<Func<T, TValue>> expression, TValue value) where T : class, new() {
+		                                                           Expression<Func<T, TValue>> expression, TValue value) where T : new() {
 			new ValidatorTester<T, TValue>(expression, validator, value).ValidateError(new T());
 		}
 
-		public static void ShouldHaveValidationErrorFor<T, TValue>(this IValidator<T> validator, Expression<Func<T, TValue>> expression, T objectToTest) where T : class {
+		public static void ShouldHaveValidationErrorFor<T, TValue>(this IValidator<T> validator, Expression<Func<T, TValue>> expression, T objectToTest) {
 			var value = expression.Compile()(objectToTest);
 			new ValidatorTester<T, TValue>(expression, validator, value).ValidateError(objectToTest);
 		}
 
 		public static void ShouldNotHaveValidationErrorFor<T, TValue>(this IValidator<T> validator,
-		                                                              Expression<Func<T, TValue>> expression, TValue value) where T : class, new() {
+		                                                              Expression<Func<T, TValue>> expression, TValue value) where T : new() {
 			new ValidatorTester<T, TValue>(expression, validator, value).ValidateNoError(new T());
 		}
 
-		public static void ShouldNotHaveValidationErrorFor<T, TValue>(this IValidator<T> validator, Expression<Func<T, TValue>> expression, T objectToTest) where T : class {
+		public static void ShouldNotHaveValidationErrorFor<T, TValue>(this IValidator<T> validator, Expression<Func<T, TValue>> expression, T objectToTest) {
 			var value = expression.Compile()(objectToTest);
 			new ValidatorTester<T, TValue>(expression, validator, value).ValidateNoError(objectToTest);
 		}

--- a/src/FluentValidation/TestHelper/ValidatorTester.cs
+++ b/src/FluentValidation/TestHelper/ValidatorTester.cs
@@ -21,7 +21,7 @@ namespace FluentValidation.TestHelper {
 	using System.Linq;
 	using System.Linq.Expressions;
 
-	public class ValidatorTester<T, TValue> where T : class {
+	public class ValidatorTester<T, TValue> {
 		private readonly IValidator<T> validator;
 		private readonly TValue value;
 		private readonly MemberAccessor<T, TValue> accessor; 


### PR DESCRIPTION
The T:class type constraint is not required (as far as I can tell), and prevents using value types like KeyValuePair.