### PR TITLE
Small change to support StopOnFirstFailure between rule chains

### DIFF
--- a/src/FluentValidation.Tests/CascadingFailuresTester.cs
+++ b/src/FluentValidation.Tests/CascadingFailuresTester.cs
@@ -119,5 +119,40 @@ namespace FluentValidation.Tests {
 			results.Errors.Count.ShouldEqual(1);
 		}
 
+	    [Test]
+	    public void ChainCascadeMode_StopOnFirstFailure_StopsChainProcessing() {
+	        validator.ChainCascadeMode = ChainCascadeMode.StopOnFirstFailure;
+
+	        validator.RuleFor(x => x.Age).GreaterThan(5);
+	        validator.RuleFor(x => x.CreditCard).Length(5, 8);
+
+	        var person = new Person() {
+	            Age = 3,
+	            CreditCard = "01"
+	        };
+
+	        var results = validator.Validate(person);
+
+            results.Errors.Count.ShouldEqual(1);
+	    }
+
+        [Test]
+        public void ChainCascadeMode_Continue_ChainsContinueToProcess()
+        {
+            validator.ChainCascadeMode = ChainCascadeMode.Continue;
+
+            validator.RuleFor(x => x.Age).GreaterThan(5);
+            validator.RuleFor(x => x.CreditCard).Length(5, 8);
+
+            var person = new Person()
+            {
+                Age = 3,
+                CreditCard = "01"
+            };
+
+            var results = validator.Validate(person);
+
+            results.Errors.Count.ShouldEqual(2);
+        }
 	}
 }

--- a/src/FluentValidation/Enums.cs
+++ b/src/FluentValidation/Enums.cs
@@ -32,6 +32,20 @@ namespace FluentValidation {
 	}
 
 	/// <summary>
+	/// Specifies how rules chains should cascase when one fails.
+	/// </summary>
+	public enum ChainCascadeMode {
+		/// <summary>
+		/// When a rule chain has a failure, execution continues to the next rule chain.
+		/// </summary>
+		Continue,
+		/// <summary>
+		/// When a rule chain has a failure, validation is stopped and no further rule chains will be executed.
+		/// </summary>
+		StopOnFirstFailure
+	}
+
+	/// <summary>
 	/// Specifies where a When/Unless condition should be applied
 	/// </summary>
 	public enum ApplyConditionTo {

--- a/src/FluentValidation/IValidator.cs
+++ b/src/FluentValidation/IValidator.cs
@@ -46,6 +46,11 @@ namespace FluentValidation {
 		/// Sets the cascade mode for all rules within this validator.
 		/// </summary>
 		CascadeMode CascadeMode { get; set; }
+
+		/// <summary>
+		/// Sets the chain cascade mode for this validator.
+		/// </summary>
+		ChainCascadeMode ChainCascadeMode { get; set; }
 	}
 
 	/// <summary>


### PR DESCRIPTION
So I'm not too familiar with this code base and my change feels a bit dirty (mostly don't like the naming similarity between the intra-chain cascade and the inter-chain cascade) but it clearly shows the functionality that I'm looking to achieve within FluentValidation. I find often that I'll have situations where the validation of one property requires that some other subset of properties already be proven valid. Or that the validation is non-trivial and I'd like it to bail as early as possible.