### PR TITLE
Fixed problem with WebApi and collections.

### DIFF
--- a/src/FluentValidation.Tests.WebApi/TestController.cs
+++ b/src/FluentValidation.Tests.WebApi/TestController.cs
@@ -23,6 +23,11 @@ namespace FluentValidation.Tests.WebApi {
 
 	public class TestController : ApiController {
 		[HttpPost]
+		public IHttpActionResult TestModel9(TestModel9 model) {
+			return OutputErrors();
+		}
+
+		[HttpPost]
 		public IHttpActionResult TestModel8(TestModel8 model) {
 			return OutputErrors();
 		}

--- a/src/FluentValidation.Tests.WebApi/TestModels.cs
+++ b/src/FluentValidation.Tests.WebApi/TestModels.cs
@@ -17,6 +17,7 @@
 #endregion
 namespace FluentValidation.Tests.WebApi {
 	using System;
+	using System.Collections.Generic;
 	using Attributes;
 	using Results;
 
@@ -123,7 +124,19 @@ namespace FluentValidation.Tests.WebApi {
 	[Validator(typeof(TestModel8Validator))]
 	public class TestModel8 {
 		public string Name { get; set; }
-		public int Age { get; set; }
+        public int Age { get; set; }
 
 	}
+
+    [Validator(typeof(TestModel9Validator))]
+    public class TestModel9 {
+        public string Name { get; set; }
+        public List<TestModel> Children { get; set; }
+    }
+
+    public class TestModel9Validator : AbstractValidator<TestModel9> {
+        public TestModel9Validator() {
+            RuleFor(m => m.Name).NotEmpty();
+        }
+    }
 }

--- a/src/FluentValidation.Tests.WebApi/WebApiIntegrationTests.cs
+++ b/src/FluentValidation.Tests.WebApi/WebApiIntegrationTests.cs
@@ -87,5 +87,13 @@ namespace FluentValidation.Tests.WebApi {
 			result.GetMessage("model.CustomProperty").ShouldEqual("Cannot be 14");
 
 		}
+
+        [Fact]
+	    public void Should_still_validate_other_properties_when_error_found_in_collection() {
+	        var result = InvokeTest<TestModel9>(@"{Children:[{}]}", "application/json");
+
+            result.IsValidField("model.Name").ShouldBeFalse();
+            result.IsValidField("model.Children[0].Name").ShouldBeFalse();
+	    }
 	}
 }

--- a/src/FluentValidation.WebApi/FluentValidationBodyModelValidator.cs
+++ b/src/FluentValidation.WebApi/FluentValidationBodyModelValidator.cs
@@ -116,7 +116,7 @@ namespace FluentValidation.WebApi
 			}
 
             // Validate this node as well
-            isValid = isValid && ShallowValidate(metadata, validationContext, container);
+            isValid = ShallowValidate(metadata, validationContext, container) && isValid;
 			
 			// Pop the object so that it can be validated again in a different path
 			validationContext.Visited.Remove(model);


### PR DESCRIPTION
When validating a model with a collection property via WebApi, if an error is found in the collection, the other validators on the parent model are ignored. I have added a unit test for this case and made a minor adjustment to keep from short-circuiting the other validators.