### PR TITLE
Pass validator provider to SetValidator

### DIFF
--- a/src/FluentValidation.Tests/RuleBuilderTests.cs
+++ b/src/FluentValidation.Tests/RuleBuilderTests.cs
@@ -85,6 +85,11 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
+        public void Should_throw_if_overriding_validator_provider_is_null() {
+            typeof (ArgumentNullException).ShouldBeThrownBy(() => builder.SetValidator((Func<Person, IValidator<string>>) null));
+        }
+
+		[Fact]
 		public void Should_throw_if_message_is_null() {
 			typeof(ArgumentNullException).ShouldBeThrownBy(() => builder.SetValidator(new TestPropertyValidator()).WithMessage(null));
 		}

--- a/src/FluentValidation.Tests/RuleBuilderTests.cs
+++ b/src/FluentValidation.Tests/RuleBuilderTests.cs
@@ -85,9 +85,9 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-        public void Should_throw_if_overriding_validator_provider_is_null() {
-            typeof (ArgumentNullException).ShouldBeThrownBy(() => builder.SetValidator((Func<Person, IValidator<string>>) null));
-        }
+		public void Should_throw_if_overriding_validator_provider_is_null() {
+			typeof (ArgumentNullException).ShouldBeThrownBy(() => builder.SetValidator((Func<Person, IValidator<string>>) null));
+		}
 
 		[Fact]
 		public void Should_throw_if_message_is_null() {

--- a/src/FluentValidation/CollectionValidatorExtensions.cs
+++ b/src/FluentValidation/CollectionValidatorExtensions.cs
@@ -62,6 +62,11 @@ namespace FluentValidation {
 				return ruleBuilder.SetValidator(validator);
 			}
 
+            public IRuleBuilderOptions<T, IEnumerable<TCollectionElement>> SetValidator<TValidator>(Func<T, TValidator> validatorProvider)
+                where TValidator : IValidator<IEnumerable<TCollectionElement>> {
+                return ruleBuilder.SetValidator(validatorProvider);
+            }
+
 			public IRuleBuilderOptions<T, IEnumerable<TCollectionElement>> Configure(Action<PropertyRule> configurator) {
 				return ((IRuleBuilderOptions<T, IEnumerable<TCollectionElement>>)ruleBuilder).Configure(configurator);
 			}

--- a/src/FluentValidation/CollectionValidatorExtensions.cs
+++ b/src/FluentValidation/CollectionValidatorExtensions.cs
@@ -62,10 +62,10 @@ namespace FluentValidation {
 				return ruleBuilder.SetValidator(validator);
 			}
 
-            public IRuleBuilderOptions<T, IEnumerable<TCollectionElement>> SetValidator<TValidator>(Func<T, TValidator> validatorProvider)
-                where TValidator : IValidator<IEnumerable<TCollectionElement>> {
-                return ruleBuilder.SetValidator(validatorProvider);
-            }
+			public IRuleBuilderOptions<T, IEnumerable<TCollectionElement>> SetValidator<TValidator>(Func<T, TValidator> validatorProvider)
+				where TValidator : IValidator<IEnumerable<TCollectionElement>> {
+				return ruleBuilder.SetValidator(validatorProvider);
+			}
 
 			public IRuleBuilderOptions<T, IEnumerable<TCollectionElement>> Configure(Action<PropertyRule> configurator) {
 				return ((IRuleBuilderOptions<T, IEnumerable<TCollectionElement>>)ruleBuilder).Configure(configurator);

--- a/src/FluentValidation/Internal/RuleBuilder.cs
+++ b/src/FluentValidation/Internal/RuleBuilder.cs
@@ -63,16 +63,16 @@ namespace FluentValidation.Internal {
 			return this;
 		}
 
-        /// <summary>
-        /// Sets the validator associated with the rule. Use with complex properties where an IValidator instance is already declared for the property type.
-        /// </summary>
-        /// <param name="validatorProvider">The validator provider to set</param>
-        public IRuleBuilderOptions<T, TProperty> SetValidator<TValidator>(Func<T, TValidator> validatorProvider)
-            where TValidator : IValidator<TProperty> {
-            validatorProvider.Guard("Cannot pass a null validatorProvider to SetValidator");
-            SetValidator(new ChildValidatorAdaptor(t => validatorProvider((T) t), typeof (TProperty)));
-            return this;
-        }
+		/// <summary>
+		/// Sets the validator associated with the rule. Use with complex properties where an IValidator instance is already declared for the property type.
+		/// </summary>
+		/// <param name="validatorProvider">The validator provider to set</param>
+		public IRuleBuilderOptions<T, TProperty> SetValidator<TValidator>(Func<T, TValidator> validatorProvider)
+			where TValidator : IValidator<TProperty> {
+			validatorProvider.Guard("Cannot pass a null validatorProvider to SetValidator");
+			SetValidator(new ChildValidatorAdaptor(t => validatorProvider((T) t), typeof (TProperty)));
+			return this;
+		}
 
 		IRuleBuilderOptions<T, TProperty> IConfigurable<PropertyRule, IRuleBuilderOptions<T, TProperty>>.Configure(Action<PropertyRule> configurator) {
 			configurator(rule);

--- a/src/FluentValidation/Internal/RuleBuilder.cs
+++ b/src/FluentValidation/Internal/RuleBuilder.cs
@@ -63,6 +63,17 @@ namespace FluentValidation.Internal {
 			return this;
 		}
 
+        /// <summary>
+        /// Sets the validator associated with the rule. Use with complex properties where an IValidator instance is already declared for the property type.
+        /// </summary>
+        /// <param name="validatorProvider">The validator provider to set</param>
+        public IRuleBuilderOptions<T, TProperty> SetValidator<TValidator>(Func<T, TValidator> validatorProvider)
+            where TValidator : IValidator<TProperty> {
+            validatorProvider.Guard("Cannot pass a null validatorProvider to SetValidator");
+            SetValidator(new ChildValidatorAdaptor(t => validatorProvider((T) t), typeof (TProperty)));
+            return this;
+        }
+
 		IRuleBuilderOptions<T, TProperty> IConfigurable<PropertyRule, IRuleBuilderOptions<T, TProperty>>.Configure(Action<PropertyRule> configurator) {
 			configurator(rule);
 			return this;

--- a/src/FluentValidation/Syntax.cs
+++ b/src/FluentValidation/Syntax.cs
@@ -48,6 +48,13 @@ namespace FluentValidation {
 		/// </summary>
 		/// <param name="validator">The validator to use</param>
 		IRuleBuilderOptions<T, TProperty> SetValidator(IValidator<TProperty> validator);
+
+        /// <summary>
+        /// Associates a validator provider with the current property rule.
+        /// </summary>
+        /// <param name="validatorProvider">The validator provider to use</param>
+        IRuleBuilderOptions<T, TProperty> SetValidator<TValidator>(Func<T, TValidator> validatorProvider)
+            where TValidator : IValidator<TProperty>;
 	}
 
 

--- a/src/FluentValidation/Syntax.cs
+++ b/src/FluentValidation/Syntax.cs
@@ -49,12 +49,12 @@ namespace FluentValidation {
 		/// <param name="validator">The validator to use</param>
 		IRuleBuilderOptions<T, TProperty> SetValidator(IValidator<TProperty> validator);
 
-        /// <summary>
-        /// Associates a validator provider with the current property rule.
-        /// </summary>
-        /// <param name="validatorProvider">The validator provider to use</param>
-        IRuleBuilderOptions<T, TProperty> SetValidator<TValidator>(Func<T, TValidator> validatorProvider)
-            where TValidator : IValidator<TProperty>;
+		/// <summary>
+		/// Associates a validator provider with the current property rule.
+		/// </summary>
+		/// <param name="validatorProvider">The validator provider to use</param>
+		IRuleBuilderOptions<T, TProperty> SetValidator<TValidator>(Func<T, TValidator> validatorProvider)
+			where TValidator : IValidator<TProperty>;
 	}
 
 

--- a/src/FluentValidation/TestHelper/ValidatorTestExtensions.cs
+++ b/src/FluentValidation/TestHelper/ValidatorTestExtensions.cs
@@ -48,7 +48,7 @@ namespace FluentValidation.TestHelper {
 			var descriptor = validator.CreateDescriptor();
 			var matchingValidators = descriptor.GetValidatorsForMember(expression.GetMember().Name);
 
-			var childValidatorTypes = matchingValidators.OfType<ChildValidatorAdaptor>().Select(x => x.Validator.GetType());
+			var childValidatorTypes = matchingValidators.OfType<ChildValidatorAdaptor>().Select(x => x.ValidatorType);
 			childValidatorTypes = childValidatorTypes.Concat(matchingValidators.OfType<ChildCollectionValidatorAdaptor>().Select(x => x.ChildValidatorType));
 
 			if (!childValidatorTypes.Any(x => x == childValidatorType)) {

--- a/src/FluentValidation/Validators/ChildValidatorAdaptor.cs
+++ b/src/FluentValidation/Validators/ChildValidatorAdaptor.cs
@@ -7,23 +7,27 @@ namespace FluentValidation.Validators {
 	using Results;
 
 	public class ChildValidatorAdaptor : NoopPropertyValidator {
-		readonly IValidator validator;
-
 		static readonly IEnumerable<ValidationFailure> EmptyResult = Enumerable.Empty<ValidationFailure>();
-
 		static readonly Task<IEnumerable<ValidationFailure>> AsyncEmptyResult = TaskHelpers.FromResult(Enumerable.Empty<ValidationFailure>());
 
-		public IValidator Validator {
-			get { return validator; }
+        readonly Func<object, IValidator> validatorProvider;
+        readonly Type validatorType;
+
+		public Type ValidatorType {
+			get { return validatorType; }
 		}
 
 		public override bool IsAsync {
 			get { return true; }
 		}
 
-		public ChildValidatorAdaptor(IValidator validator) {
-			this.validator = validator;
-		}
+	    public ChildValidatorAdaptor(IValidator validator) : this(_ => validator, validator.GetType()) {
+	    }
+
+	    public ChildValidatorAdaptor(Func<object, IValidator> validatorProvider, Type validatorType) {
+            this.validatorProvider = validatorProvider;
+            this.validatorType = validatorType;
+        }
 
 		public override IEnumerable<ValidationFailure> Validate(PropertyValidatorContext context) {
 			return ValidateInternal(
@@ -60,7 +64,7 @@ namespace FluentValidation.Validators {
 		}
 
 		protected virtual IValidator GetValidator(PropertyValidatorContext context) {
-			return Validator;
+			return validatorProvider(context.Instance);
 		}
 
 		protected ValidationContext CreateNewValidationContextForChildValidator(object instanceToValidate, PropertyValidatorContext context) {

--- a/src/FluentValidation/Validators/ChildValidatorAdaptor.cs
+++ b/src/FluentValidation/Validators/ChildValidatorAdaptor.cs
@@ -10,8 +10,8 @@ namespace FluentValidation.Validators {
 		static readonly IEnumerable<ValidationFailure> EmptyResult = Enumerable.Empty<ValidationFailure>();
 		static readonly Task<IEnumerable<ValidationFailure>> AsyncEmptyResult = TaskHelpers.FromResult(Enumerable.Empty<ValidationFailure>());
 
-        readonly Func<object, IValidator> validatorProvider;
-        readonly Type validatorType;
+		readonly Func<object, IValidator> validatorProvider;
+		readonly Type validatorType;
 
 		public Type ValidatorType {
 			get { return validatorType; }
@@ -21,13 +21,13 @@ namespace FluentValidation.Validators {
 			get { return true; }
 		}
 
-	    public ChildValidatorAdaptor(IValidator validator) : this(_ => validator, validator.GetType()) {
-	    }
+		public ChildValidatorAdaptor(IValidator validator) : this(_ => validator, validator.GetType()) {
+		}
 
-	    public ChildValidatorAdaptor(Func<object, IValidator> validatorProvider, Type validatorType) {
-            this.validatorProvider = validatorProvider;
-            this.validatorType = validatorType;
-        }
+		public ChildValidatorAdaptor(Func<object, IValidator> validatorProvider, Type validatorType) {
+			this.validatorProvider = validatorProvider;
+			this.validatorType = validatorType;
+		}
 
 		public override IEnumerable<ValidationFailure> Validate(PropertyValidatorContext context) {
 			return ValidateInternal(


### PR DESCRIPTION
I added the ability to pass a validator provider to set validator so the child validator has access to the parent object.  Similar functionality already exists for SetCollectionValidator. 