### PR TITLE
Polish resources update

### DIFF
--- a/src/FluentValidation/Resources/Messages.pl.resx
+++ b/src/FluentValidation/Resources/Messages.pl.resx
@@ -162,4 +162,10 @@
   <data name="exclusivebetween_error" xml:space="preserve">
     <value>'{PropertyName}' musi się zawierać pomiędzy {From} i {To} (wyłącznie). Wprowadzono {Value}.</value>
   </data>
+  <data name="CreditCardError" xml:space="preserve">
+    <value>Pole '{PropertyName}' nie zawiera poprawnego numer karty kredytowej.</value>
+  </data>
+  <data name="scale_precision_error" xml:space="preserve">
+    <value>Wartość pola '{PropertyName}' nie może mieć więcej niż {expectedPrecision} cyfr z dopuszczalną dokładnością {expectedScale} cyfr po przecinku. Znaleziono {digits} cyfr i {actualScale} cyfr po przecinku.</value>
+  </data>
 </root>

--- a/src/FluentValidation/Resources/Messages.pl.resx
+++ b/src/FluentValidation/Resources/Messages.pl.resx
@@ -154,7 +154,7 @@
     <value>Wartość pola '{PropertyName}' powinna być równa '{ComparisonValue}'.</value>
   </data>
   <data name="exact_length_error" xml:space="preserve">
-    <value>Maksymalna długość pola '{PropertyName}' to {MaxLength} znaki(ów). Wprowadzono {TotalLength} znaki(ów).</value>
+    <value>Pole '{PropertyName}' musi posiadać długość {MaxLength} znaki(ów). Wprowadzono {TotalLength} znaki(ów).</value>
   </data>
 	<data name="inclusivebetween_error" xml:space="preserve">
     <value>'{PropertyName}' musi się zawierać pomiędzy {From} i {To}. Wprowadzono {Value}.</value>


### PR DESCRIPTION
I have added two missing entries in polish resources and corrected one that was wrong. In 'exact_length_error' the value was 'Maximal field lenght is X characters. Y characters were entered.'