### PR TITLE
Added support for ValidatorAttribute on method parameters

### DIFF
--- a/src/FluentValidation.Portable/FluentValidation.Portable.csproj
+++ b/src/FluentValidation.Portable/FluentValidation.Portable.csproj
@@ -72,6 +72,9 @@
     <Compile Include="..\FluentValidation\Internal\RulesetValidatorSelector.cs">
       <Link>RulesetValidatorSelector.cs</Link>
     </Compile>
+    <Compile Include="..\FluentValidation\IParameterValidatorFactory.cs">
+      <Link>IParameterValidatorFactory.cs</Link>
+    </Compile>
     <Compile Include="..\FluentValidation\MemberAccessor.cs">
       <Link>MemberAccessor.cs</Link>
     </Compile>

--- a/src/FluentValidation.Portable40/FluentValidation.Portable40.csproj
+++ b/src/FluentValidation.Portable40/FluentValidation.Portable40.csproj
@@ -71,6 +71,9 @@
     <Compile Include="..\FluentValidation\Internal\RulesetValidatorSelector.cs">
       <Link>RulesetValidatorSelector.cs</Link>
     </Compile>
+    <Compile Include="..\FluentValidation\IParameterValidatorFactory.cs">
+      <Link>IParameterValidatorFactory.cs</Link>
+    </Compile>
     <Compile Include="..\FluentValidation\MemberAccessor.cs">
       <Link>MemberAccessor.cs</Link>
     </Compile>

--- a/src/FluentValidation.Tests/AttributedValidatorFactoryTester.cs
+++ b/src/FluentValidation.Tests/AttributedValidatorFactoryTester.cs
@@ -1,56 +1,113 @@
-namespace FluentValidation.Tests {
+namespace FluentValidation.Tests
+{
 	using Attributes;
+	using System;
+	using System.Collections.Generic;
+	using System.Linq;
+	using System.Reflection;
 	using Xunit;
 
-	
-	public class AttributedValidatorFactoryTester {
-		IValidatorFactory factory;
+	public class AttributedValidatorFactoryTester
+	{
+		private readonly AttributedValidatorFactory factory;
 
-		public AttributedValidatorFactoryTester() {
+		public AttributedValidatorFactoryTester()
+		{
 			factory = new AttributedValidatorFactory();
 		}
 
 		[Fact]
-		public void Should_instantiate_validator() {
+		public void Should_instantiate_validator()
+		{
 			var validator = factory.GetValidator<AttributedPerson>();
 			validator.ShouldBe<TestValidator>();
 		}
 
 		[Fact]
-		public void Should_instantiate_validator_non_generic() {
+		public void Should_instantiate_validator_non_generic()
+		{
 			var validator = factory.GetValidator(typeof(AttributedPerson));
 			validator.ShouldBe<TestValidator>();
 		}
 
 		[Fact]
-		public void Should_return_null_when_null_is_passed_to_GetValidator() {
-			factory.GetValidator(null).ShouldBeNull();
+		public void Should_return_null_when_null_is_passed_to_GetValidator()
+		{
+			factory.GetValidator((Type)null).ShouldBeNull();
 		}
 
 		[Fact]
-		public void Should_return_null_when_type_has_no_attribute() {
+		public void Should_return_null_when_type_has_no_attribute()
+		{
 			factory.GetValidator<NonAttributedPerson>().ShouldBeNull();
 		}
 
 		[Fact]
-		public void Should_return_null_when_attribute_has_no_type() {
+		public void Should_return_null_when_attribute_has_no_type()
+		{
 			factory.GetValidator<AttributedPersonWithNoType>().ShouldBeNull();
 		}
 
-		[Validator(typeof(TestValidator))]
-		private class AttributedPerson {
+		[Fact]
+		public void Should_instantiate_parameter_validator()
+		{
+			var parameter = GetTestParameters().First(p => p.Name == "attributedArgument");
+			var validator = factory.GetValidator(parameter);
+			validator.ShouldBe<TestValidator>();
 		}
 
-		private class NonAttributedPerson {
-			
+		[Fact]
+		public void Should_return_null_when_parameter_null_is_passed_to_GetValidator()
+		{
+			factory.GetValidator((ParameterInfo)null).ShouldBeNull();
+		}
+
+		[Fact]
+		public void Should_return_null_when_parameter_has_no_attribute()
+		{
+			var parameter = GetTestParameters().First(p => p.Name == "nonAttributedArgument");
+			factory.GetValidator(parameter).ShouldBeNull();
+		}
+
+		[Fact]
+		public void Should_return_null_when_parameter_attribute_has_no_type()
+		{
+			var parameter = GetTestParameters().First(p => p.Name == "attributedArgumentWithNoType");
+			factory.GetValidator(parameter).ShouldBeNull();
+		}
+
+		private static IList<ParameterInfo> GetTestParameters()
+		{
+			return typeof(SomeService).GetMethod("SomeMethod").GetParameters();
+		}
+
+		[Validator(typeof(TestValidator))]
+		private class AttributedPerson
+		{
+		}
+
+		private class NonAttributedPerson
+		{
 		}
 
 		[Validator(null)]
-		private class AttributedPersonWithNoType {
-			
+		private class AttributedPersonWithNoType
+		{
 		}
 
-		private class TestValidator : AbstractValidator<AttributedPerson> {
+		private class TestValidator : AbstractValidator<AttributedPerson>
+		{
+		}
+
+		private class SomeService
+		{
+			public void SomeMethod(
+				[Validator(typeof(TestValidator))] string attributedArgument,
+				[Validator(null)] string attributedArgumentWithNoType,
+				string nonAttributedArgument
+			)
+			{
+			}
 		}
 	}
 }

--- a/src/FluentValidation/Attributes/AttributedValidatorFactory.cs
+++ b/src/FluentValidation/Attributes/AttributedValidatorFactory.cs
@@ -1,51 +1,113 @@
 #region License
-// Copyright (c) Jeremy Skinner (http://www.jeremyskinner.co.uk)
-// 
-// Licensed under the Apache License, Version 2.0 (the "License"); 
-// you may not use this file except in compliance with the License. 
-// You may obtain a copy of the License at 
-// 
-// http://www.apache.org/licenses/LICENSE-2.0 
-// 
-// Unless required by applicable law or agreed to in writing, software 
-// distributed under the License is distributed on an "AS IS" BASIS, 
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
-// See the License for the specific language governing permissions and 
-// limitations under the License.
-// 
-// The latest version of this file can be found at https://github.com/jeremyskinner/FluentValidation
-#endregion
 
-namespace FluentValidation.Attributes {
-	using System;
+// Copyright (c) Jeremy Skinner (http://www.jeremyskinner.co.uk)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// The latest version of this file can be found at https://github.com/jeremyskinner/FluentValidation
+
+#endregion License
+
+namespace FluentValidation.Attributes
+{
 	using Internal;
+	using System;
+	using System.Reflection;
 
 	/// <summary>
-	/// Implementation of IValidatorFactory that looks for ValidatorAttribute instances on the specified type in order to provide the validator instance.
+	/// Implementation of <see cref="IValidatorFactory"/> and <see cref="IParameterValidatorFactory"/> that looks for
+	/// the <see cref="ValidatorAttribute"/> instance on the specified <see cref="Type"/> or
+	/// <see cref="ParameterInfo"/> in order to provide the validator instance.
 	/// </summary>
-	public class AttributedValidatorFactory : IValidatorFactory {
-		readonly InstanceCache cache = new InstanceCache();
+	public class AttributedValidatorFactory : IValidatorFactory, IParameterValidatorFactory
+	{
+		private readonly Func<Type, IValidator> instanceFactory;
+
+		private readonly InstanceCache cache = new InstanceCache();
+
+		/// <summary>
+		/// Creates an instance of <see cref="AttributedValidatorFactory"/>.
+		/// </summary>
+		public AttributedValidatorFactory()
+		{
+			instanceFactory = null;
+		}
+
+		/// <summary>
+		/// Creates an instance of <see cref="AttributedValidatorFactory"/> with the supplied instance factory delegate
+		/// used for creation of <see cref="IValidator"/> instances.
+		/// </summary>
+		/// <param name="instanceFactory">The <see cref="IValidator"/> instance factory delegate.</param>
+		public AttributedValidatorFactory(Func<Type, IValidator> instanceFactory)
+		{
+			this.instanceFactory = instanceFactory;
+		}
 
 		/// <summary>
 		/// Gets a validator for the appropriate type.
 		/// </summary>
-		public IValidator<T> GetValidator<T>() {
+		public IValidator<T> GetValidator<T>()
+		{
 			return (IValidator<T>)GetValidator(typeof(T));
 		}
 
 		/// <summary>
 		/// Gets a validator for the appropriate type.
 		/// </summary>
-		public virtual IValidator GetValidator(Type type) {
+		/// <returns>Created <see cref="IValidator"/> instance; <see langword="null"/> if a validator cannot be
+		/// created.</returns>
+		public virtual IValidator GetValidator(Type type)
+		{
 			if (type == null)
+			{
 				return null;
+			}
 
 			var attribute = type.GetValidatorAttribute();
 
-			if (attribute == null || attribute.ValidatorType == null)
-				return null;
+			return GetValidator(attribute);
+		}
 
-			return cache.GetOrCreateInstance(attribute.ValidatorType) as IValidator;
+		/// <summary>
+		/// Gets a validator for <paramref name="parameterInfo"/>.
+		/// </summary>
+		/// <param name="parameterInfo">The <see cref="ParameterInfo"/> instance to get a validator for.</param>
+		/// <returns>Created <see cref="IValidator"/> instance; <see langword="null"/> if a validator cannot be
+		/// created.</returns>
+		public virtual IValidator GetValidator(ParameterInfo parameterInfo)
+		{
+			if (parameterInfo == null)
+			{
+				return null;
+			}
+
+			var attribute = parameterInfo.GetValidatorAttribute();
+
+			return GetValidator(attribute);
+		}
+
+		private IValidator GetValidator(ValidatorAttribute attribute)
+		{
+			if (attribute == null || attribute.ValidatorType == null)
+			{
+				return null;
+			}
+
+			var validator = instanceFactory == null
+				? cache.GetOrCreateInstance(attribute.ValidatorType)
+				: cache.GetOrCreateInstance(attribute.ValidatorType, instanceFactory);
+
+			return validator as IValidator;
 		}
 	}
 }

--- a/src/FluentValidation/Attributes/ValidatorAttribute.cs
+++ b/src/FluentValidation/Attributes/ValidatorAttribute.cs
@@ -1,37 +1,40 @@
 #region License
-// Copyright (c) Jeremy Skinner (http://www.jeremyskinner.co.uk)
-// 
-// Licensed under the Apache License, Version 2.0 (the "License"); 
-// you may not use this file except in compliance with the License. 
-// You may obtain a copy of the License at 
-// 
-// http://www.apache.org/licenses/LICENSE-2.0 
-// 
-// Unless required by applicable law or agreed to in writing, software 
-// distributed under the License is distributed on an "AS IS" BASIS, 
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
-// See the License for the specific language governing permissions and 
-// limitations under the License.
-// 
-// The latest version of this file can be found at https://github.com/jeremyskinner/FluentValidation
-#endregion
 
-namespace FluentValidation.Attributes {
+// Copyright (c) Jeremy Skinner (http://www.jeremyskinner.co.uk)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// The latest version of this file can be found at https://github.com/jeremyskinner/FluentValidation
+
+#endregion License
+
+namespace FluentValidation.Attributes
+{
 	using System;
 
 	/// <summary>
-	/// Validator attribute to define the class that will describe the Validation rules
+	/// Validator attribute to define the class that will describe the Validation rules.
 	/// </summary>
-	[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+	[AttributeUsage(AttributeTargets.Class | AttributeTargets.Parameter)]
 	public class ValidatorAttribute : Attribute
 	{
 		/// <summary>
-		/// The type of the validator used to validate the current type.
+		/// The type of the validator used to validate the current type or parameter.
 		/// </summary>
 		public Type ValidatorType { get; private set; }
 
 		/// <summary>
-		/// Creates an instance of the ValidatorAttribute allowing a validator type to be specified.
+		/// Creates an instance of <see cref="ValidatorAttribute"/> allowing a validator type to be specified.
 		/// </summary>
 		public ValidatorAttribute(Type validatorType)
 		{

--- a/src/FluentValidation/FluentValidation.csproj
+++ b/src/FluentValidation/FluentValidation.csproj
@@ -81,6 +81,7 @@
     <Compile Include="AbstractValidator.cs" />
     <Compile Include="AssemblyInfo.cs" />
     <Compile Include="Internal\Compatibility.cs" />
+    <Compile Include="IParameterValidatorFactory.cs" />
     <Compile Include="TaskHelpers\TaskHelpers.cs" />
     <Compile Include="TaskHelpers\TaskHelpersExtensions.cs" />
     <Compile Include="AssemblyScanner.cs" />

--- a/src/FluentValidation/IParameterValidatorFactory.cs
+++ b/src/FluentValidation/IParameterValidatorFactory.cs
@@ -1,0 +1,18 @@
+﻿namespace FluentValidation
+{
+	using System.Reflection;
+
+	/// <summary>
+	/// Gets validators for method parameters.
+	/// </summary>
+	public interface IParameterValidatorFactory
+	{
+		/// <summary>
+		/// Gets a validator for <paramref name="parameterInfo"/>.
+		/// </summary>
+		/// <param name="parameterInfo">The <see cref="ParameterInfo"/> instance to get a validator for.</param>
+		/// <returns>Created <see cref="IValidator"/> instance; <see langword="null"/> if a validator cannot be
+		/// created.</returns>
+		IValidator GetValidator(ParameterInfo parameterInfo);
+	}
+}

--- a/src/FluentValidation/Internal/Compatibility.cs
+++ b/src/FluentValidation/Internal/Compatibility.cs
@@ -1,31 +1,36 @@
 ﻿#region License
+
 // Copyright (c) Jeremy Skinner (http://www.jeremyskinner.co.uk)
-// 
-// Licensed under the Apache License, Version 2.0 (the "License"); 
-// you may not use this file except in compliance with the License. 
-// You may obtain a copy of the License at 
-// 
-// http://www.apache.org/licenses/LICENSE-2.0 
-// 
-// Unless required by applicable law or agreed to in writing, software 
-// distributed under the License is distributed on an "AS IS" BASIS, 
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
-// See the License for the specific language governing permissions and 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // The latest version of this file can be found at http://fluentvalidation.codeplex.com
-#endregion
-namespace FluentValidation.Internal {
+
+#endregion License
+
+namespace FluentValidation.Internal
+{
+	using Attributes;
 	using System;
 	using System.Reflection;
-	using Attributes;
-	using Resources;
 
 	/// <summary>
 	/// Keeps all the conditional compilation in one place.
 	/// </summary>
-	internal static class Compatibility {
+	internal static class Compatibility
+	{
 #if PORTABLE40
+
 		public static PropertyInfo GetRuntimeProperty(this Type type, string propertyName)
 		{
 			return type.GetProperty(propertyName, BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance);
@@ -35,57 +40,70 @@ namespace FluentValidation.Internal {
 		{
 			return type.GetMethod(name, BindingFlags.Instance | BindingFlags.Public);
 		}
+
 #endif
 
 #if PORTABLE || CoreCLR
+
 		public static bool IsAssignableFrom(this Type type, Type otherType)
 		{
 			return type.GetTypeInfo().IsAssignableFrom(otherType.GetTypeInfo());
 		}
-#endif 
 
-		public static Func<string> CreateGetter(this PropertyInfo property) {
-			Func<string> accessor;
-#if PORTABLE || CoreCLR
-            accessor = (Func<string>)property.GetMethod.CreateDelegate(typeof(Func<string>));
-#else
-			accessor = (Func<string>)Delegate.CreateDelegate(typeof(Func<string>), property.GetGetMethod());
 #endif
-			return accessor;
+
+		public static Func<string> CreateGetter(this PropertyInfo property)
+		{
+#if PORTABLE || CoreCLR
+			return (Func<string>)property.GetMethod.CreateDelegate(typeof(Func<string>));
+#else
+			return (Func<string>)Delegate.CreateDelegate(typeof(Func<string>), property.GetGetMethod());
+#endif
 		}
 
-		public static ValidatorAttribute GetValidatorAttribute(this Type type) {
+		public static ValidatorAttribute GetValidatorAttribute(this Type type)
+		{
 #if PORTABLE || CoreCLR
-            var attribute = (ValidatorAttribute)type.GetTypeInfo().GetCustomAttribute<ValidatorAttribute>(true);
+			return type.GetTypeInfo().GetCustomAttribute<ValidatorAttribute>(true);
 #else
-			var attribute = (ValidatorAttribute)Attribute.GetCustomAttribute(type, typeof(ValidatorAttribute));
+			return (ValidatorAttribute)Attribute.GetCustomAttribute(type, typeof(ValidatorAttribute));
 #endif
-			return attribute;
 		}
 
-		public static Assembly GetAssembly(this Type type) {
+		public static ValidatorAttribute GetValidatorAttribute(this ParameterInfo parameterInfo)
+		{
 #if PORTABLE || CoreCLR
-                    return type.GetTypeInfo().Assembly;
+			return parameterInfo.GetCustomAttribute<ValidatorAttribute>(true);
+#else
+			return (ValidatorAttribute)Attribute.GetCustomAttribute(parameterInfo, typeof(ValidatorAttribute));
+#endif
+		}
+
+		public static Assembly GetAssembly(this Type type)
+		{
+#if PORTABLE || CoreCLR
+			return type.GetTypeInfo().Assembly;
 #else
 			return type.Assembly;
 #endif
 		}
 
-		public static MethodInfo GetDeclaredMethod(this Type type, string name) {
+		public static MethodInfo GetDeclaredMethod(this Type type, string name)
+		{
 #if PORTABLE || CoreCLR
-            return type.GetTypeInfo().GetDeclaredMethod(name);
+			return type.GetTypeInfo().GetDeclaredMethod(name);
 #else
 			return type.GetMethod(name, new Type[0]);
 #endif
 		}
 
-        public static bool IsGenericType(this Type type)
-        {
+		public static bool IsGenericType(this Type type)
+		{
 #if PORTABLE || CoreCLR
-            return type.GetTypeInfo().IsGenericType;
+			return type.GetTypeInfo().IsGenericType;
 #else
-            return type.IsGenericType;
+			return type.IsGenericType;
 #endif
-        }
+		}
 	}
 }


### PR DESCRIPTION
As discussed in #133 . I've added a separate interface `IParameterValidatorFactory` so that breaking changes are not introduced in `IValidatorFactory`. Also I added non-default `AttributedValidatorFactory` constructor taking a `Func<Type, IValidator>` to be used for validator creation. This might be useful for integration with IoC containers.
P.S. Let me know if I need to revert formatting changes