### PR TITLE
Add extension method AddToModelState to FluentValidation.WebApi

### DIFF
--- a/src/FluentValidation.Tests.WebApi/FluentValidation.Tests.WebApi.csproj
+++ b/src/FluentValidation.Tests.WebApi/FluentValidation.Tests.WebApi.csproj
@@ -72,6 +72,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestController.cs" />
     <Compile Include="TestModels.cs" />
+    <Compile Include="ValidationResultExtensionTests.cs" />
     <Compile Include="WebApiBaseTest.cs" />
     <Compile Include="WebApiIntegrationTests.cs" />
   </ItemGroup>

--- a/src/FluentValidation.Tests.WebApi/ValidationResultExtensionTests.cs
+++ b/src/FluentValidation.Tests.WebApi/ValidationResultExtensionTests.cs
@@ -1,0 +1,72 @@
+#region License
+// Copyright (c) Jeremy Skinner (http://www.jeremyskinner.co.uk)
+// 
+// Licensed under the Apache License, Version 2.0 (the "License"); 
+// you may not use this file except in compliance with the License. 
+// You may obtain a copy of the License at 
+// 
+// http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS, 
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+// 
+// The latest version of this file can be found at http://www.codeplex.com/FluentValidation
+#endregion
+
+namespace FluentValidation.Tests.WebApi {
+    using Xunit;
+    using Results;
+    using System.Web.Http.ModelBinding;
+    using FluentValidation.WebApi;
+
+    public class ValidationResultExtensionTests {
+		private ValidationResult result;
+
+		public ValidationResultExtensionTests() {
+			result = new ValidationResult(new[] {
+				new ValidationFailure("foo", "A foo error occurred", "x"),
+				new ValidationFailure("bar", "A bar error occurred", "y"),
+			});
+		}
+
+		[Fact]
+		public void Should_persist_to_modelstate() {
+			var modelstate = new ModelStateDictionary();
+			result.AddToModelState(modelstate, null);
+
+			modelstate.IsValid.ShouldBeFalse();
+			modelstate["foo"].Errors[0].ErrorMessage.ShouldEqual("A foo error occurred");
+			modelstate["bar"].Errors[0].ErrorMessage.ShouldEqual("A bar error occurred");
+
+			modelstate["foo"].Value.AttemptedValue.ShouldEqual("x");
+			modelstate["bar"].Value.AttemptedValue.ShouldEqual("y");
+		}
+
+		[Fact]
+		public void Should_persist_modelstate_with_empty_prefix() {
+			var modelstate = new ModelStateDictionary();
+			result.AddToModelState(modelstate, "");
+			modelstate["foo"].Errors[0].ErrorMessage.ShouldEqual("A foo error occurred");
+		}
+
+		[Fact]
+		public void Should_persist_to_modelstate_with_prefix() {
+			var modelstate = new ModelStateDictionary();
+			result.AddToModelState(modelstate, "baz");
+
+			modelstate.IsValid.ShouldBeFalse();
+			modelstate["baz.foo"].Errors[0].ErrorMessage.ShouldEqual("A foo error occurred");
+			modelstate["baz.bar"].Errors[0].ErrorMessage.ShouldEqual("A bar error occurred");
+		}
+
+		[Fact]
+		public void Should_do_nothing_if_result_is_valid() {
+			var modelState = new ModelStateDictionary();
+			new ValidationResult().AddToModelState(modelState, null);
+			modelState.IsValid.ShouldBeTrue();
+		}
+	}
+}

--- a/src/FluentValidation.WebApi/FluentValidation.WebApi.csproj
+++ b/src/FluentValidation.WebApi/FluentValidation.WebApi.csproj
@@ -62,6 +62,7 @@
     <Compile Include="FluentValidationBodyModelValidator.cs" />
     <Compile Include="FluentValidationModelValidator.cs" />
     <Compile Include="FluentValidationModelValidatorProvider.cs" />
+    <Compile Include="ValidationResultExtension.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\FluentValidation.snk">

--- a/src/FluentValidation.WebApi/ValidationResultExtension.cs
+++ b/src/FluentValidation.WebApi/ValidationResultExtension.cs
@@ -1,0 +1,44 @@
+#region License
+// Copyright (c) Jeremy Skinner (http://www.jeremyskinner.co.uk)
+// 
+// Licensed under the Apache License, Version 2.0 (the "License"); 
+// you may not use this file except in compliance with the License. 
+// You may obtain a copy of the License at 
+// 
+// http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS, 
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+// 
+// The latest version of this file can be found at http://www.codeplex.com/FluentValidation
+#endregion
+
+namespace FluentValidation.WebApi {
+    using System.Collections.Generic;
+    using System.Globalization;
+    using Results;
+    using System.Web.Http.ModelBinding;
+    using System.Web.Http.ValueProviders;
+
+    public static class ValidationResultExtension {
+		/// <summary>
+		/// Stores the errors in a ValidationResult object to the specified modelstate dictionary.
+		/// </summary>
+		/// <param name="result">The validation result to store</param>
+		/// <param name="modelState">The ModelStateDictionary to store the errors in.</param>
+		/// <param name="prefix">An optional prefix. If ommitted, the property names will be the keys. If specified, the prefix will be concatenatd to the property name with a period. Eg "user.Name"</param>
+		public static void AddToModelState(this ValidationResult result, ModelStateDictionary modelState, string prefix) {
+			if (!result.IsValid) {
+				foreach (var error in result.Errors) {
+					string key = string.IsNullOrEmpty(prefix) ? error.PropertyName : prefix + "." + error.PropertyName;
+					modelState.AddModelError(key, error.ErrorMessage);
+					//To work around an issue with MVC: SetModelValue must be called if AddModelError is called.
+					modelState.SetModelValue(key, new ValueProviderResult(error.AttemptedValue ?? "", (error.AttemptedValue ?? "").ToString(), CultureInfo.CurrentCulture));
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
I needed this method for a WebApi project and noticed it was missing.

I also [updated the wiki](https://github.com/JeremySkinner/FluentValidation/wiki/h.-MVC#firing-validations-manually) with info about this extension method