### PR TITLE
Added WithErrorCode Method to pass Custom Error Code #150

### DIFF
--- a/src/FluentValidation.Tests/AbstractValidatorTester.cs
+++ b/src/FluentValidation.Tests/AbstractValidatorTester.cs
@@ -66,20 +66,20 @@ namespace FluentValidation.Tests {
 			result.Errors[0].ErrorMessage.ShouldEqual("Foo");
 		}
 
-        [Fact]
-        public void WithErrorCode_should_override_error_code() {
-            validator.RuleFor(x => x.Forename).NotNull().WithErrorCode("ErrCode101");
-            var result = validator.Validate(new Person());
-            result.Errors[0].ErrorCode.ShouldEqual("ErrCode101");
-        }
+		[Fact]
+		public void WithErrorCode_should_override_error_code() {
+			validator.RuleFor(x => x.Forename).NotNull().WithErrorCode("ErrCode101");
+			var result = validator.Validate(new Person());
+			result.Errors[0].ErrorCode.ShouldEqual("ErrCode101");
+		}
 
-        [Fact]
-        public void WithMessage_and_WithErrorCode_should_override_error_message_and_error_code() {
-            validator.RuleFor(x => x.Forename).NotNull().WithMessage("Foo").WithErrorCode("ErrCode101");
-            var result = validator.Validate(new Person());
-            result.Errors[0].ErrorMessage.ShouldEqual("Foo");
-            result.Errors[0].ErrorCode.ShouldEqual("ErrCode101");
-        }
+		[Fact]
+		public void WithMessage_and_WithErrorCode_should_override_error_message_and_error_code() {
+			validator.RuleFor(x => x.Forename).NotNull().WithMessage("Foo").WithErrorCode("ErrCode101");
+			var result = validator.Validate(new Person());
+			result.Errors[0].ErrorMessage.ShouldEqual("Foo");
+			result.Errors[0].ErrorCode.ShouldEqual("ErrCode101");
+		}
 
 		[Fact]
 		public void WithName_should_override_field_name() {

--- a/src/FluentValidation.Tests/AbstractValidatorTester.cs
+++ b/src/FluentValidation.Tests/AbstractValidatorTester.cs
@@ -66,6 +66,13 @@ namespace FluentValidation.Tests {
 			result.Errors[0].ErrorMessage.ShouldEqual("Foo");
 		}
 
+        [Fact]
+        public void WithErrorCode_should_override_error_code() {
+            validator.RuleFor(x => x.Forename).NotNull().WithErrorCode("ErrCode101");
+            var result = validator.Validate(new Person());
+            result.Errors[0].ErrorCode.ShouldEqual("ErrCode101");
+        }
+
 		[Fact]
 		public void WithName_should_override_field_name() {
 			validator.RuleFor(x => x.Forename).NotNull().WithName("First Name");

--- a/src/FluentValidation.Tests/AbstractValidatorTester.cs
+++ b/src/FluentValidation.Tests/AbstractValidatorTester.cs
@@ -73,6 +73,14 @@ namespace FluentValidation.Tests {
             result.Errors[0].ErrorCode.ShouldEqual("ErrCode101");
         }
 
+        [Fact]
+        public void WithMessage_and_WithErrorCode_should_override_error_message_and_error_code() {
+            validator.RuleFor(x => x.Forename).NotNull().WithMessage("Foo").WithErrorCode("ErrCode101");
+            var result = validator.Validate(new Person());
+            result.Errors[0].ErrorMessage.ShouldEqual("Foo");
+            result.Errors[0].ErrorCode.ShouldEqual("ErrCode101");
+        }
+
 		[Fact]
 		public void WithName_should_override_field_name() {
 			validator.RuleFor(x => x.Forename).NotNull().WithName("First Name");

--- a/src/FluentValidation/DefaultValidatorOptions.cs
+++ b/src/FluentValidation/DefaultValidatorOptions.cs
@@ -116,6 +116,22 @@ namespace FluentValidation {
 			});
 		} 
 
+        /// <summary>
+        /// Specifies a custom error code to use if validation fails.
+        /// </summary>
+        /// <param name="rule">The current rule</param>
+        /// <param name="errorCode">The error code to use</param>
+        /// <returns></returns>
+        public static IRuleBuilderOptions<T, TProperty> WithErrorCode<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, string errorCode) {
+            errorCode.Guard("A error code must be specified when calling WithErrorCode.");
+
+            return rule.Configure(config =>
+            {
+                config.CurrentValidator.ErrorCodeSource = new StaticStringSource(errorCode);
+
+            });
+        }
+
 		/// <summary>
 		/// Specifies a custom error message resource to use when validation fails.
 		/// </summary>
@@ -332,6 +348,6 @@ namespace FluentValidation {
 				return new Func<T, object>[0];
 			}
 			return objects.Select(obj => new Func<T, object>(x => obj)).ToArray();
-		} 
+		}
 	}
 }

--- a/src/FluentValidation/DefaultValidatorOptions.cs
+++ b/src/FluentValidation/DefaultValidatorOptions.cs
@@ -114,23 +114,21 @@ namespace FluentValidation {
 					.Select(func => new Func<object, object, object>((instance, value) => func((T)instance, (TProperty)value)))
 					.ForEach(config.CurrentValidator.CustomMessageFormatArguments.Add);
 			});
-		} 
+		}
 
-        /// <summary>
-        /// Specifies a custom error code to use if validation fails.
-        /// </summary>
-        /// <param name="rule">The current rule</param>
-        /// <param name="errorCode">The error code to use</param>
-        /// <returns></returns>
-        public static IRuleBuilderOptions<T, TProperty> WithErrorCode<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, string errorCode) {
-            errorCode.Guard("A error code must be specified when calling WithErrorCode.");
+		/// <summary>
+		/// Specifies a custom error code to use if validation fails.
+		/// </summary>
+		/// <param name="rule">The current rule</param>
+		/// <param name="errorCode">The error code to use</param>
+		/// <returns></returns>
+		public static IRuleBuilderOptions<T, TProperty> WithErrorCode<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, string errorCode) {
+			errorCode.Guard("A error code must be specified when calling WithErrorCode.");
 
-            return rule.Configure(config =>
-            {
-                config.CurrentValidator.ErrorCodeSource = new StaticStringSource(errorCode);
-
-            });
-        }
+			return rule.Configure(config => {
+				config.CurrentValidator.ErrorCodeSource = new StaticStringSource(errorCode);
+			});
+		}
 
 		/// <summary>
 		/// Specifies a custom error message resource to use when validation fails.
@@ -348,6 +346,6 @@ namespace FluentValidation {
 				return new Func<T, object>[0];
 			}
 			return objects.Select(obj => new Func<T, object>(x => obj)).ToArray();
-		}
+		} 
 	}
 }

--- a/src/FluentValidation/Validators/DelegatingValidator.cs
+++ b/src/FluentValidation/Validators/DelegatingValidator.cs
@@ -56,6 +56,7 @@ namespace FluentValidation.Validators {
 			get { return InnerValidator.ErrorCodeSource; }
 			set { InnerValidator.ErrorCodeSource = value; }
 		}
+
 		public IEnumerable<ValidationFailure> Validate(PropertyValidatorContext context) {
 			if (condition(context.Instance)) {
 				return InnerValidator.Validate(context);

--- a/src/FluentValidation/Validators/DelegatingValidator.cs
+++ b/src/FluentValidation/Validators/DelegatingValidator.cs
@@ -51,7 +51,11 @@ namespace FluentValidation.Validators {
 			get { return InnerValidator.ErrorMessageSource; }
 			set { InnerValidator.ErrorMessageSource = value; }
 		}
-
+        
+        public IStringSource ErrorCodeSource {
+            get { return InnerValidator.ErrorCodeSource; }
+            set { InnerValidator.ErrorCodeSource = value; }
+        }
 		public IEnumerable<ValidationFailure> Validate(PropertyValidatorContext context) {
 			if (condition(context.Instance)) {
 				return InnerValidator.Validate(context);

--- a/src/FluentValidation/Validators/DelegatingValidator.cs
+++ b/src/FluentValidation/Validators/DelegatingValidator.cs
@@ -51,11 +51,11 @@ namespace FluentValidation.Validators {
 			get { return InnerValidator.ErrorMessageSource; }
 			set { InnerValidator.ErrorMessageSource = value; }
 		}
-        
-        public IStringSource ErrorCodeSource {
-            get { return InnerValidator.ErrorCodeSource; }
-            set { InnerValidator.ErrorCodeSource = value; }
-        }
+
+		public IStringSource ErrorCodeSource {
+			get { return InnerValidator.ErrorCodeSource; }
+			set { InnerValidator.ErrorCodeSource = value; }
+		}
 		public IEnumerable<ValidationFailure> Validate(PropertyValidatorContext context) {
 			if (condition(context.Instance)) {
 				return InnerValidator.Validate(context);

--- a/src/FluentValidation/Validators/IPropertyValidator.cs
+++ b/src/FluentValidation/Validators/IPropertyValidator.cs
@@ -44,5 +44,6 @@ namespace FluentValidation.Validators {
 		ICollection<Func<object, object, object>> CustomMessageFormatArguments { get; }
 		Func<object, object> CustomStateProvider { get; set; }
 		IStringSource ErrorMessageSource { get; set; }
+        IStringSource ErrorCodeSource { get; set; }
 	}
 }

--- a/src/FluentValidation/Validators/IPropertyValidator.cs
+++ b/src/FluentValidation/Validators/IPropertyValidator.cs
@@ -44,6 +44,6 @@ namespace FluentValidation.Validators {
 		ICollection<Func<object, object, object>> CustomMessageFormatArguments { get; }
 		Func<object, object> CustomStateProvider { get; set; }
 		IStringSource ErrorMessageSource { get; set; }
-        IStringSource ErrorCodeSource { get; set; }
+		IStringSource ErrorCodeSource { get; set; }
 	}
 }

--- a/src/FluentValidation/Validators/NoopPropertyValidator.cs
+++ b/src/FluentValidation/Validators/NoopPropertyValidator.cs
@@ -36,6 +36,11 @@ namespace FluentValidation.Validators {
 			get { return false; }
 		}
 
+        public IStringSource ErrorCodeSource {
+            get { return null; }
+            set { }
+        }
+
 		public abstract IEnumerable<ValidationFailure> Validate(PropertyValidatorContext context);
 
 		public virtual Task<IEnumerable<ValidationFailure>> ValidateAsync(PropertyValidatorContext context, CancellationToken cancellation) {

--- a/src/FluentValidation/Validators/NoopPropertyValidator.cs
+++ b/src/FluentValidation/Validators/NoopPropertyValidator.cs
@@ -36,10 +36,10 @@ namespace FluentValidation.Validators {
 			get { return false; }
 		}
 
-        public IStringSource ErrorCodeSource {
-            get { return null; }
-            set { }
-        }
+		public IStringSource ErrorCodeSource {
+			get { return null; }
+			set { }
+		}
 
 		public abstract IEnumerable<ValidationFailure> Validate(PropertyValidatorContext context);
 

--- a/src/FluentValidation/Validators/PropertyValidator.cs
+++ b/src/FluentValidation/Validators/PropertyValidator.cs
@@ -32,8 +32,8 @@ namespace FluentValidation.Validators {
 		private readonly List<Func<object, object, object>> customFormatArgs = new List<Func<object, object, object>>();
 		private IStringSource errorSource;
 		private IStringSource originalErrorSource;
-        private IStringSource errorCodeSource;
-        private IStringSource originalErrorCodeSource;
+		private IStringSource errorCodeSource;
+		private IStringSource originalErrorCodeSource;
 
 		public virtual bool IsAsync {
 			get { return false; }
@@ -114,8 +114,8 @@ namespace FluentValidation.Validators {
 			failure.FormattedMessageArguments = context.MessageFormatter.AdditionalArguments;
 			failure.FormattedMessagePlaceholderValues = context.MessageFormatter.PlaceholderValues;
 			failure.ResourceName = errorSource.ResourceName;
-            failure.ErrorCode = (errorCodeSource != null) ? errorCodeSource.GetString() : originalErrorSource.ResourceName;
-            
+			failure.ErrorCode = (errorCodeSource != null) ? errorCodeSource.GetString() : originalErrorSource.ResourceName;
+
 			if (CustomStateProvider != null) {
 				failure.CustomState = CustomStateProvider(context.Instance);
 			}
@@ -132,17 +132,17 @@ namespace FluentValidation.Validators {
 			return error;
 		}
 
-        public IStringSource ErrorCodeSource {
-            get { return errorCodeSource; }
-            set
-            {
-                if (value == null)
-                {
-                    throw new ArgumentNullException("value");
-                }
+		public IStringSource ErrorCodeSource {
+			get { return errorCodeSource; }
+			set
+			{
+				if (value == null)
+				{
+					throw new ArgumentNullException("value");
+				}
 
-                errorCodeSource = value;
-            }
-        }
+				errorCodeSource = value;
+			}
+		}
 	}
 }

--- a/src/FluentValidation/Validators/PropertyValidator.cs
+++ b/src/FluentValidation/Validators/PropertyValidator.cs
@@ -114,11 +114,8 @@ namespace FluentValidation.Validators {
 			failure.FormattedMessageArguments = context.MessageFormatter.AdditionalArguments;
 			failure.FormattedMessagePlaceholderValues = context.MessageFormatter.PlaceholderValues;
 			failure.ResourceName = errorSource.ResourceName;
-			failure.ErrorCode = originalErrorSource.ResourceName;
-            if (errorCodeSource != null)
-            {
-                failure.ErrorCode = errorCodeSource.GetString();
-            }
+            failure.ErrorCode = (errorCodeSource != null) ? errorCodeSource.GetString() : originalErrorSource.ResourceName;
+            
 			if (CustomStateProvider != null) {
 				failure.CustomState = CustomStateProvider(context.Instance);
 			}

--- a/src/FluentValidation/Validators/PropertyValidator.cs
+++ b/src/FluentValidation/Validators/PropertyValidator.cs
@@ -32,6 +32,8 @@ namespace FluentValidation.Validators {
 		private readonly List<Func<object, object, object>> customFormatArgs = new List<Func<object, object, object>>();
 		private IStringSource errorSource;
 		private IStringSource originalErrorSource;
+        private IStringSource errorCodeSource;
+        private IStringSource originalErrorCodeSource;
 
 		public virtual bool IsAsync {
 			get { return false; }
@@ -113,7 +115,10 @@ namespace FluentValidation.Validators {
 			failure.FormattedMessagePlaceholderValues = context.MessageFormatter.PlaceholderValues;
 			failure.ResourceName = errorSource.ResourceName;
 			failure.ErrorCode = originalErrorSource.ResourceName;
-
+            if (errorCodeSource != null)
+            {
+                failure.ErrorCode = errorCodeSource.GetString();
+            }
 			if (CustomStateProvider != null) {
 				failure.CustomState = CustomStateProvider(context.Instance);
 			}
@@ -129,5 +134,18 @@ namespace FluentValidation.Validators {
 			string error = context.MessageFormatter.BuildMessage(errorSource.GetString());
 			return error;
 		}
+
+        public IStringSource ErrorCodeSource {
+            get { return errorCodeSource; }
+            set
+            {
+                if (value == null)
+                {
+                    throw new ArgumentNullException("value");
+                }
+
+                errorCodeSource = value;
+            }
+        }
 	}
 }


### PR DESCRIPTION
Hi Jeremy,

As discussed we have added a new method (i.e. WithErrorCode) to pass custom error code. With this method Custom/user-defined Error Code can passed both independently or along with Error Message. 
As suggested by you we are using the existing ErrorCode Property (in ValidationFailure.cs) to persist the Custom ErrorCode passed by users.

[Test Cases] 
We have executed all the existing test cases and they are passing successfully. 

We have also added two new test cases considering following scenarios:

1. Passing Just ErrorCode in WithErrorCode method.
2. Passing both Error Code and ErrorMessage together in a chaining with methods WithErrorCode & WithErrorMessge respectively.    
   
[Documentation]

We have also created the documentation for the newly added method, pls find it at below link. 

https://docs.google.com/document/d/1B0N3qXErBp3SfvSiB3xWYryTh0FH0xVAzPxyCleCP3o/edit?usp=sharing


Please review all the work done by us and let us know for any corrections or further changes.


Regards,

Vikas
