### PR TITLE
Add support for [Flags] enumerations in EnumValidator.

### DIFF
--- a/src/FluentValidation.Tests/EnumValidatorTests.cs
+++ b/src/FluentValidation.Tests/EnumValidatorTests.cs
@@ -1,5 +1,24 @@
+#region License
+// Copyright (c) Jeremy Skinner (http://www.jeremyskinner.co.uk)
+// 
+// Licensed under the Apache License, Version 2.0 (the "License"); 
+// you may not use this file except in compliance with the License. 
+// You may obtain a copy of the License at 
+// 
+// http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS, 
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+// 
+// The latest version of this file can be found at https://github.com/jeremyskinner/FluentValidation
+#endregion
+
 namespace FluentValidation.Tests
 {
+	using System;
 	using System.Linq;
 	using Xunit;
 
@@ -73,9 +92,191 @@ namespace FluentValidation.Tests
 			result.IsValid.ShouldBeFalse();
 		}
 
-		public class Foo
+		[Fact]
+		public void Flags_enum_valid_when_using_bitwise_value()
+		{
+			var inlineValidator = new InlineValidator<FlagsEnumPoco>();
+			inlineValidator.RuleFor(x => x.SByteValue).IsInEnum();
+			inlineValidator.RuleFor(x => x.ByteValue).IsInEnum();
+			inlineValidator.RuleFor(x => x.Int16Value).IsInEnum();
+			inlineValidator.RuleFor(x => x.UInt16Value).IsInEnum();
+			inlineValidator.RuleFor(x => x.Int32Value).IsInEnum();
+			inlineValidator.RuleFor(x => x.UInt32Value).IsInEnum();
+			inlineValidator.RuleFor(x => x.Int64Value).IsInEnum();
+			inlineValidator.RuleFor(x => x.UInt64Value).IsInEnum();
+
+			var poco = new FlagsEnumPoco();
+			poco.PopulateWithValidValues();
+
+			var result = inlineValidator.Validate(poco);
+			result.IsValid.ShouldBeTrue();
+		}
+
+		[Fact]
+		public void Flags_enum_invalid_when_using_outofrange_positive_value()
+		{
+			var inlineValidator = new InlineValidator<FlagsEnumPoco>();
+			inlineValidator.RuleFor(x => x.SByteValue).IsInEnum();
+			inlineValidator.RuleFor(x => x.ByteValue).IsInEnum();
+			inlineValidator.RuleFor(x => x.Int16Value).IsInEnum();
+			inlineValidator.RuleFor(x => x.UInt16Value).IsInEnum();
+			inlineValidator.RuleFor(x => x.Int32Value).IsInEnum();
+			inlineValidator.RuleFor(x => x.UInt32Value).IsInEnum();
+			inlineValidator.RuleFor(x => x.Int64Value).IsInEnum();
+			inlineValidator.RuleFor(x => x.UInt64Value).IsInEnum();
+
+			var poco = new FlagsEnumPoco();
+			poco.PopulateWithInvalidPositiveValues();
+
+			var result = inlineValidator.Validate(poco);
+			result.IsValid.ShouldBeFalse();
+			result.Errors.SingleOrDefault(x => x.PropertyName == "ByteValue").ShouldNotBeNull();
+			result.Errors.SingleOrDefault(x => x.PropertyName == "SByteValue").ShouldNotBeNull();
+			result.Errors.SingleOrDefault(x => x.PropertyName == "Int16Value").ShouldNotBeNull();
+			result.Errors.SingleOrDefault(x => x.PropertyName == "UInt16Value").ShouldNotBeNull();
+			result.Errors.SingleOrDefault(x => x.PropertyName == "Int32Value").ShouldNotBeNull();
+			result.Errors.SingleOrDefault(x => x.PropertyName == "UInt32Value").ShouldNotBeNull();
+			result.Errors.SingleOrDefault(x => x.PropertyName == "Int64Value").ShouldNotBeNull();
+			result.Errors.SingleOrDefault(x => x.PropertyName == "UInt64Value").ShouldNotBeNull();
+		}
+
+		[Fact]
+		public void Flags_enum_invalid_when_using_outofrange_negative_value()
+		{
+			var inlineValidator = new InlineValidator<FlagsEnumPoco>();
+			inlineValidator.RuleFor(x => x.SByteValue).IsInEnum();
+			inlineValidator.RuleFor(x => x.ByteValue).IsInEnum();
+			inlineValidator.RuleFor(x => x.Int16Value).IsInEnum();
+			inlineValidator.RuleFor(x => x.UInt16Value).IsInEnum();
+			inlineValidator.RuleFor(x => x.Int32Value).IsInEnum();
+			inlineValidator.RuleFor(x => x.UInt32Value).IsInEnum();
+			inlineValidator.RuleFor(x => x.Int64Value).IsInEnum();
+			inlineValidator.RuleFor(x => x.UInt64Value).IsInEnum();
+
+			var poco = new FlagsEnumPoco();
+			poco.PopulateWithInvalidNegativeValues();
+
+			var result = inlineValidator.Validate(poco);
+			result.IsValid.ShouldBeFalse();
+			result.Errors.SingleOrDefault(x => x.PropertyName == "SByteValue").ShouldNotBeNull();
+			result.Errors.SingleOrDefault(x => x.PropertyName == "Int16Value").ShouldNotBeNull();
+			result.Errors.SingleOrDefault(x => x.PropertyName == "Int32Value").ShouldNotBeNull();
+			result.Errors.SingleOrDefault(x => x.PropertyName == "Int64Value").ShouldNotBeNull();
+		}
+
+		private class Foo
 		{
 			public EnumGender? Gender { get; set; }
 		}
+
+		#region Flag enum helpers
+		private class FlagsEnumPoco
+		{
+			public SByteEnum SByteValue { get; set; }
+			public ByteEnum ByteValue { get; set; }
+			public Int16Enum Int16Value { get; set; }
+			public UInt16Enum UInt16Value { get; set; }
+			public Int32Enum Int32Value { get; set; }
+			public UInt32Enum UInt32Value { get; set; }
+			public Int64Enum Int64Value { get; set; }
+			public UInt64Enum UInt64Value { get; set; }
+
+			public void PopulateWithValidValues()
+			{
+				SByteValue = SByteEnum.B | SByteEnum.C;
+				ByteValue = ByteEnum.B | ByteEnum.C;
+				Int16Value = Int16Enum.B | Int16Enum.C;
+				UInt16Value = UInt16Enum.B | UInt16Enum.C;
+				Int32Value = Int32Enum.B | Int32Enum.C;
+				UInt32Value = UInt32Enum.B | UInt32Enum.C;
+				Int64Value = Int64Enum.B | Int64Enum.C;
+				UInt64Value = UInt64Enum.B | UInt64Enum.C;
+			}
+
+			public void PopulateWithInvalidPositiveValues()
+			{
+				SByteValue = (SByteEnum)123;
+				ByteValue = (ByteEnum)123;
+				Int16Value = (Int16Enum)123;
+				UInt16Value = (UInt16Enum)123;
+				Int32Value = (Int32Enum)123;
+				UInt32Value = (UInt32Enum)123;
+				Int64Value = (Int64Enum)123;
+				UInt64Value = (UInt64Enum)123;
+			}
+
+			public void PopulateWithInvalidNegativeValues()
+			{
+				SByteValue = (SByteEnum)(-123);
+				Int16Value = (Int16Enum)(-123);
+				Int32Value = (Int32Enum)(-123);
+				Int64Value = (Int64Enum)(-123);
+			}
+		}
+
+		[Flags]
+		private enum SByteEnum : sbyte
+		{
+			A = 0,
+			B = 1,
+			C = 2
+		}
+
+		[Flags]
+		private enum ByteEnum : byte
+		{
+			A = 0,
+			B = 1,
+			C = 2
+		}
+
+		[Flags]
+		private enum Int16Enum : short
+		{
+			A = 0,
+			B = 1,
+			C = 2
+		}
+
+		[Flags]
+		private enum UInt16Enum : ushort
+		{
+			A = 0,
+			B = 1,
+			C = 2
+		}
+
+		[Flags]
+		private enum Int32Enum : int
+		{
+			A = 0,
+			B = 1,
+			C = 2
+		}
+
+		[Flags]
+		private enum UInt32Enum : uint
+		{
+			A = 0,
+			B = 1,
+			C = 2
+		}
+
+		[Flags]
+		private enum Int64Enum : long
+		{
+			A = 0,
+			B = 1,
+			C = 2
+		}
+
+		[Flags]
+		private enum UInt64Enum : ulong
+		{
+			A = 0,
+			B = 1,
+			C = 2
+		}
+		#endregion
 	}
 }

--- a/src/FluentValidation/Internal/Compatibility.cs
+++ b/src/FluentValidation/Internal/Compatibility.cs
@@ -61,13 +61,19 @@ namespace FluentValidation.Internal
 #endif
 		}
 
-		public static ValidatorAttribute GetValidatorAttribute(this Type type)
+		public static TAttribute GetCustomAttributeCompatible<TAttribute>(this Type type)
+			where TAttribute : Attribute
 		{
 #if PORTABLE || CoreCLR
-			return type.GetTypeInfo().GetCustomAttribute<ValidatorAttribute>(true);
+			return type.GetTypeInfo().GetCustomAttribute<TAttribute>(true);
 #else
-			return (ValidatorAttribute)Attribute.GetCustomAttribute(type, typeof(ValidatorAttribute));
+			return (TAttribute)Attribute.GetCustomAttribute(type, typeof(TAttribute));
 #endif
+		}
+
+		public static ValidatorAttribute GetValidatorAttribute(this Type type)
+		{
+			return type.GetCustomAttributeCompatible<ValidatorAttribute>();
 		}
 
 		public static ValidatorAttribute GetValidatorAttribute(this ParameterInfo parameterInfo)

--- a/src/FluentValidation/Resources/Messages.Designer.cs
+++ b/src/FluentValidation/Resources/Messages.Designer.cs
@@ -89,7 +89,7 @@ namespace FluentValidation.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The value for &apos;{PropertyName}&apos; is invalid..
+        ///   Looks up a localized string similar to &apos;{PropertyName}&apos; has a range of values which does not include &apos;{PropertyValue}&apos;..
         /// </summary>
         public static string enum_error {
             get {

--- a/src/FluentValidation/Resources/Messages.resx
+++ b/src/FluentValidation/Resources/Messages.resx
@@ -175,6 +175,6 @@
     <value>'{PropertyName}' must be empty.</value>
   </data>
   <data name="enum_error" xml:space="preserve">
-    <value>The value for '{PropertyName}' is invalid.</value>
+    <value>'{PropertyName}' has a range of values which does not include '{PropertyValue}'.</value>
   </data>
 </root>

--- a/src/FluentValidation/Validators/EnumValidator.cs
+++ b/src/FluentValidation/Validators/EnumValidator.cs
@@ -1,22 +1,142 @@
-﻿namespace FluentValidation.Validators {
+﻿#region License
+// Copyright (c) Jeremy Skinner (http://www.jeremyskinner.co.uk)
+// 
+// Licensed under the Apache License, Version 2.0 (the "License"); 
+// you may not use this file except in compliance with the License. 
+// You may obtain a copy of the License at 
+// 
+// http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS, 
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+// 
+// The latest version of this file can be found at https://github.com/jeremyskinner/FluentValidation
+#endregion
+
+namespace FluentValidation.Validators
+{
 	using System;
 	using FluentValidation.Internal;
 	using Resources;
 
-	public class EnumValidator : PropertyValidator {
-		private readonly Type _enumType;
+	public class EnumValidator : PropertyValidator
+	{
+		private readonly Type enumType;
 
 		public EnumValidator(Type enumType) : base(() => Messages.enum_error) {
-			this._enumType = enumType;
+			this.enumType = enumType;
 		}
 
 		protected override bool IsValid(PropertyValidatorContext context) {
 			if (context.PropertyValue == null) return true;
 
-			Type enumType = Nullable.GetUnderlyingType(_enumType) ?? _enumType;
+			var underlyingEnumType = Nullable.GetUnderlyingType(enumType) ?? enumType;
 
-			if (!enumType.IsEnum()) return false;
-			return Enum.IsDefined(enumType, context.PropertyValue);
+			if (!underlyingEnumType.IsEnum()) return false;
+
+			if (underlyingEnumType.GetCustomAttributeCompatible<FlagsAttribute>() != null)
+			{
+				return IsFlagsEnumDefined(underlyingEnumType, context.PropertyValue);
+			}
+
+			return Enum.IsDefined(underlyingEnumType, context.PropertyValue);
+		}
+
+		private static bool IsFlagsEnumDefined(Type enumType, object value) {
+			var typeName = Enum.GetUnderlyingType(enumType).Name;
+
+			switch (typeName)
+			{
+				case "Byte":
+					{
+						var typedValue = (byte)value;
+						return EvaluateFlagEnumValues(typedValue, enumType);
+					}
+
+				case "Int16":
+					{
+						var typedValue = (short)value;
+
+						if (typedValue < 0)
+						{
+							return false;
+						}
+
+						return EvaluateFlagEnumValues(Convert.ToUInt64(typedValue), enumType);
+					}
+
+				case "Int32":
+					{
+						var typedValue = (int)value;
+
+						if (typedValue < 0)
+						{
+							return false;
+						}
+
+						return EvaluateFlagEnumValues(Convert.ToUInt64(typedValue), enumType);
+					}
+
+				case "Int64":
+					{
+						var typedValue = (long)value;
+
+						if (typedValue < 0)
+						{
+							return false;
+						}
+
+						return EvaluateFlagEnumValues(Convert.ToUInt64(typedValue), enumType);
+					}
+
+				case "SByte":
+					{
+						var typedValue = (sbyte)value;
+
+						if (typedValue < 0)
+						{
+							return false;
+						}
+
+						return EvaluateFlagEnumValues(Convert.ToUInt64(typedValue), enumType);
+					}
+
+				case "UInt16":
+					{
+						var typedValue = (ushort)value;
+						return EvaluateFlagEnumValues(typedValue, enumType);
+					}
+
+				case "UInt32":
+					{
+						var typedValue = (uint)value;
+						return EvaluateFlagEnumValues(typedValue, enumType);
+					}
+
+				case "UInt64":
+					{
+						var typedValue = (ulong)value;
+						return EvaluateFlagEnumValues(typedValue, enumType);
+					}
+
+				default:
+					var message = string.Format("Unexpected typeName of '{0}' during flags enum evaluation.", typeName);
+					throw new ArgumentOutOfRangeException("typeName", message);
+			}
+		}
+
+		private static bool EvaluateFlagEnumValues(ulong value, Type enumType) {
+			ulong mask = 0;
+
+			foreach (var enumValue in Enum.GetValues(enumType)) {
+				var enumValueAsUInt64 = Convert.ToUInt64(enumValue);
+				mask = mask | enumValueAsUInt64;
+			}
+
+			return (mask & value) == value;
 		}
 	}
 }


### PR DESCRIPTION
- Misc change: add missing file headers to EnumValidator and EnumValidatorTest
- Misc change: make validation message in resource file more descriptive
>> Including a user-provided value as part of a system's output is potentially vulnerable to injection style attacks; however, since out-of-range enum values will only contain numeric values, its safe to include {PropertyValue} as part of the validation error message.

---
In response to: #222 

@JeremySkinner .. I did my best to maintain style with the theme of the repo (tabs, curly-brace, ..). Also, the implementation I used is somewhat verbose, but the intent was to minimize unnecessary object allocations.

@Lechus .. I changed the validation message that you included in your original commit. I think the additional information will be useful (and safe) to someone who isn't aware that out-of-range numeric values can be used for a corresponding enum member.