### PR TITLE
Specify dependencies for other supported TFM's.

### DIFF
--- a/.build/FluentValidation-signed.nuspec
+++ b/.build/FluentValidation-signed.nuspec
@@ -13,7 +13,8 @@
     <language>en-US</language>
     <releaseNotes>https://github.com/JeremySkinner/FluentValidation/blob/master/Changelog.txt</releaseNotes>
     <dependencies>
-      <group targetFramework=".NETStandard1.3">
+      <group targetFramework="net45" />
+      <group targetFramework="netstandard1.0">
         <dependency id="System.Collections" version="4.0.11-rc2-24027" />
         <dependency id="System.Diagnostics.Debug" version="4.0.11-rc2-24027" />
         <dependency id="System.Diagnostics.Tools" version="4.0.1-rc2-24027" />
@@ -28,6 +29,39 @@
         <dependency id="System.Text.RegularExpressions" version="4.0.12-rc2-24027" />
         <dependency id="System.Threading" version="4.0.11-rc2-24027" />
         <dependency id="System.Threading.Tasks" version="4.0.11-rc2-24027" />
+      </group>
+      <group targetFramework="portable-net40+sl50+wp80+win8+wpa81" />
+      <group targetFramework="portable-net45+win8+wp8+wpa81">
+        <dependency id="System.Collections" version="4.0.11" />
+        <dependency id="System.Diagnostics.Debug" version="4.0.11" />
+        <dependency id="System.Diagnostics.Tools" version="4.0.1" />
+        <dependency id="System.Globalization" version="4.0.11" />
+        <dependency id="System.Linq" version="4.1.0" />
+        <dependency id="System.Linq.Expressions" version="4.0.11" />
+        <dependency id="System.Reflection" version="4.1.0" />
+        <dependency id="System.Reflection.Extensions" version="4.0.1" />
+        <dependency id="System.Resources.ResourceManager" version="4.0.1" />
+        <dependency id="System.Runtime" version="4.1.0" />
+        <dependency id="System.Runtime.Extensions" version="4.1.0" />
+        <dependency id="System.Text.RegularExpressions" version="4.0.12" />
+        <dependency id="System.Threading" version="4.0.11" />
+        <dependency id="System.Threading.Tasks" version="4.0.11" />
+      </group>
+      <group targetFramework="uap10.0">
+        <dependency id="System.Collections" version="4.0.11" />
+        <dependency id="System.Diagnostics.Debug" version="4.0.11" />
+        <dependency id="System.Diagnostics.Tools" version="4.0.1" />
+        <dependency id="System.Globalization" version="4.0.11" />
+        <dependency id="System.Linq" version="4.1.0" />
+        <dependency id="System.Linq.Expressions" version="4.0.11" />
+        <dependency id="System.Reflection" version="4.1.0" />
+        <dependency id="System.Reflection.Extensions" version="4.0.1" />
+        <dependency id="System.Resources.ResourceManager" version="4.0.1" />
+        <dependency id="System.Runtime" version="4.1.0" />
+        <dependency id="System.Runtime.Extensions" version="4.1.0" />
+        <dependency id="System.Text.RegularExpressions" version="4.0.12" />
+        <dependency id="System.Threading" version="4.0.11" />
+        <dependency id="System.Threading.Tasks" version="4.0.11" />
       </group>
     </dependencies>
   </metadata>

--- a/.build/FluentValidation.nuspec
+++ b/.build/FluentValidation.nuspec
@@ -13,7 +13,8 @@
     <language>en-US</language>
     <releaseNotes>https://github.com/JeremySkinner/FluentValidation/blob/master/Changelog.txt</releaseNotes>
     <dependencies>
-      <group targetFramework=".NETStandard1.0">
+      <group targetFramework="net45" />
+      <group targetFramework="netstandard1.0">
         <dependency id="System.Collections" version="4.0.11-rc2-24027" />
         <dependency id="System.Diagnostics.Debug" version="4.0.11-rc2-24027" />
         <dependency id="System.Diagnostics.Tools" version="4.0.1-rc2-24027" />
@@ -28,6 +29,39 @@
         <dependency id="System.Text.RegularExpressions" version="4.0.12-rc2-24027" />
         <dependency id="System.Threading" version="4.0.11-rc2-24027" />
         <dependency id="System.Threading.Tasks" version="4.0.11-rc2-24027" />
+      </group>
+      <group targetFramework="portable-net40+sl50+wp80+win8+wpa81" />
+      <group targetFramework="portable-net45+win8+wp8+wpa81">
+        <dependency id="System.Collections" version="4.0.11" />
+        <dependency id="System.Diagnostics.Debug" version="4.0.11" />
+        <dependency id="System.Diagnostics.Tools" version="4.0.1" />
+        <dependency id="System.Globalization" version="4.0.11" />
+        <dependency id="System.Linq" version="4.1.0" />
+        <dependency id="System.Linq.Expressions" version="4.0.11" />
+        <dependency id="System.Reflection" version="4.1.0" />
+        <dependency id="System.Reflection.Extensions" version="4.0.1" />
+        <dependency id="System.Resources.ResourceManager" version="4.0.1" />
+        <dependency id="System.Runtime" version="4.1.0" />
+        <dependency id="System.Runtime.Extensions" version="4.1.0" />
+        <dependency id="System.Text.RegularExpressions" version="4.0.12" />
+        <dependency id="System.Threading" version="4.0.11" />
+        <dependency id="System.Threading.Tasks" version="4.0.11" />
+      </group>
+      <group targetFramework="uap10.0">
+        <dependency id="System.Collections" version="4.0.11" />
+        <dependency id="System.Diagnostics.Debug" version="4.0.11" />
+        <dependency id="System.Diagnostics.Tools" version="4.0.1" />
+        <dependency id="System.Globalization" version="4.0.11" />
+        <dependency id="System.Linq" version="4.1.0" />
+        <dependency id="System.Linq.Expressions" version="4.0.11" />
+        <dependency id="System.Reflection" version="4.1.0" />
+        <dependency id="System.Reflection.Extensions" version="4.0.1" />
+        <dependency id="System.Resources.ResourceManager" version="4.0.1" />
+        <dependency id="System.Runtime" version="4.1.0" />
+        <dependency id="System.Runtime.Extensions" version="4.1.0" />
+        <dependency id="System.Text.RegularExpressions" version="4.0.12" />
+        <dependency id="System.Threading" version="4.0.11" />
+        <dependency id="System.Threading.Tasks" version="4.0.11" />
       </group>
     </dependencies>
   </metadata>

--- a/src/CommonAssemblyInfo.cs
+++ b/src/CommonAssemblyInfo.cs
@@ -1,4 +1,4 @@
 using System.Reflection;
 
-[assembly : AssemblyVersion("6.3.3.0")]
-[assembly : AssemblyFileVersion("6.3.3.0")]
+[assembly : AssemblyVersion("6.3.4.0")]
+[assembly : AssemblyFileVersion("6.3.4.0")]


### PR DESCRIPTION
There's an issue when installing the package for .NET v4.5 project, the netstandard1.0 dependencies are unnecessarily pulled down.  In this change the exact dependencies are specified for each target framework so that correct set of dependencies will be installed when installing the FluentValidation package.

Fixes #268.