### PR TITLE
AspNetCore MVC integration

### DIFF
--- a/FluentValidation.sln
+++ b/FluentValidation.sln
@@ -7,7 +7,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		Changelog.txt = Changelog.txt
 		FluentValidation.snk = FluentValidation.snk
-		src\FluentValidation.Tests-vnext\global.json = src\FluentValidation.Tests-vnext\global.json
+		global.json = global.json
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FluentValidation", "src\FluentValidation\FluentValidation.csproj", "{DAE0249B-4F69-4AC9-9A17-AA23E0795316}"
@@ -64,6 +64,8 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "FluentValidation.Tests.dotn
 	ProjectSection(ProjectDependencies) = postProject
 		{50E89C50-57F3-4AFC-85C6-4DCF2EDEA5FA} = {50E89C50-57F3-4AFC-85C6-4DCF2EDEA5FA}
 	EndProjectSection
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "FluentValidation.MvcCore", "src\FluentValidation.MvcCore\FluentValidation.MvcCore.xproj", "{C8C80107-125A-4D48-9DDA-F8F388C0E507}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -127,6 +129,10 @@ Global
 		{FCCE03DA-9FD1-4483-976C-EA6821A1E514}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FCCE03DA-9FD1-4483-976C-EA6821A1E514}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FCCE03DA-9FD1-4483-976C-EA6821A1E514}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C8C80107-125A-4D48-9DDA-F8F388C0E507}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C8C80107-125A-4D48-9DDA-F8F388C0E507}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C8C80107-125A-4D48-9DDA-F8F388C0E507}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C8C80107-125A-4D48-9DDA-F8F388C0E507}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/global.json
+++ b/global.json
@@ -1,5 +1,4 @@
 {
   "projects": [
-    //"src/wrap"
   ]
 }

--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
   "projects": [
-    "src/wrap"
+    //"src/wrap"
   ]
 }

--- a/src/FluentValidation.MvcCore/EXAMPLE.md
+++ b/src/FluentValidation.MvcCore/EXAMPLE.md
@@ -1,0 +1,15 @@
+﻿### Example
+```csharp
+using FluentValidation;
+
+public class Startup {
+   ...
+  
+   public void ConfigureServices(IServiceCollection services) {
+
+            services.AddMvc()
+                    .AddFluentValidation(Assembly.GetEntryAssembly());
+   }
+}
+
+```

--- a/src/FluentValidation.MvcCore/FluentValidation.MvcCore.xproj
+++ b/src/FluentValidation.MvcCore/FluentValidation.MvcCore.xproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>c8c80107-125a-4d48-9dda-f8f388c0e507</ProjectGuid>
+    <RootNamespace>FluentValidation.MvcCore</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/FluentValidation.MvcCore/FluentValidationModelValidatorProvider.cs
+++ b/src/FluentValidation.MvcCore/FluentValidationModelValidatorProvider.cs
@@ -13,36 +13,30 @@ namespace FluentValidation.MvcCore
         private IValidatorFactory _ValidatorFactory;
 
         public FluentValidationModelValidatorProvider(IValidatorFactory validatorFactory) {
-            if (validatorFactory == null) 
+            if (validatorFactory == null)
                 throw new ArgumentNullException(nameof(validatorFactory));
-                
+
             _ValidatorFactory = validatorFactory;
         }
 
-        public void CreateValidators(ModelValidatorProviderContext context)
-        {
+        public void CreateValidators(ModelValidatorProviderContext context) {
             var validator = CreateValidator(context);
-            if (! IsValidatingProperty(context) && validator != null) 
- 			{ 
- 				context.Results.Add(new ValidatorItem 
-                 { 
-                     Validator = new FluentValidationModelValidator(validator), 
-                     IsReusable = false 
-                 }); 
- 			} 
+            if (!IsValidatingProperty(context) && validator != null) {
+                context.Results.Add(new ValidatorItem {
+                    Validator = new FluentValidationModelValidator(validator),
+                    IsReusable = false
+                });
+            }
         }
 
-        protected virtual IValidator CreateValidator(ModelValidatorProviderContext context)
-        {
-            if (IsValidatingProperty(context))
-            {
+        protected virtual IValidator CreateValidator(ModelValidatorProviderContext context) {
+            if (IsValidatingProperty(context)) {
                 return _ValidatorFactory.GetValidator(context.ModelMetadata.ContainerType);
             }
             return _ValidatorFactory.GetValidator(context.ModelMetadata.ModelType);
         }
 
-        protected virtual bool IsValidatingProperty(ModelValidatorProviderContext context)
-        {
+        protected virtual bool IsValidatingProperty(ModelValidatorProviderContext context) {
             return context.ModelMetadata.ContainerType != null && !string.IsNullOrEmpty(context.ModelMetadata.PropertyName);
         }
     }
@@ -51,13 +45,11 @@ namespace FluentValidation.MvcCore
     {
         private IValidator _validator;
 
-        public FluentValidationModelValidator(IValidator validator)
-        {
+        public FluentValidationModelValidator(IValidator validator) {
             _validator = validator;
         }
 
-        public IEnumerable<ModelValidationResult> Validate(ModelValidationContext context)
-        {
+        public IEnumerable<ModelValidationResult> Validate(ModelValidationContext context) {
             var model = context.Model;
 
             var result = _validator.Validate(model);
@@ -67,8 +59,7 @@ namespace FluentValidation.MvcCore
 
         }
 
-        public bool IsRequired
-        {
+        public bool IsRequired {
             get { return false; }
         }
     }

--- a/src/FluentValidation.MvcCore/FluentValidationModelValidatorProvider.cs
+++ b/src/FluentValidation.MvcCore/FluentValidationModelValidatorProvider.cs
@@ -1,0 +1,75 @@
+using System.Collections.Generic;
+using FluentValidation;
+using System.Linq;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
+using System;
+
+namespace FluentValidation.MvcCore
+{
+    //TODO: Need support for CustomizeValidatorAttribute and client-side
+
+    public class FluentValidationModelValidatorProvider : IModelValidatorProvider
+    {
+        private IValidatorFactory _ValidatorFactory;
+
+        public FluentValidationModelValidatorProvider(IValidatorFactory validatorFactory) {
+            if (validatorFactory == null) 
+                throw new ArgumentNullException(nameof(validatorFactory));
+                
+            _ValidatorFactory = validatorFactory;
+        }
+
+        public void CreateValidators(ModelValidatorProviderContext context)
+        {
+            var validator = CreateValidator(context);
+            if (! IsValidatingProperty(context) && validator != null) 
+ 			{ 
+ 				context.Results.Add(new ValidatorItem 
+                 { 
+                     Validator = new FluentValidationModelValidator(validator), 
+                     IsReusable = false 
+                 }); 
+ 			} 
+        }
+
+        protected virtual IValidator CreateValidator(ModelValidatorProviderContext context)
+        {
+            if (IsValidatingProperty(context))
+            {
+                return _ValidatorFactory.GetValidator(context.ModelMetadata.ContainerType);
+            }
+            return _ValidatorFactory.GetValidator(context.ModelMetadata.ModelType);
+        }
+
+        protected virtual bool IsValidatingProperty(ModelValidatorProviderContext context)
+        {
+            return context.ModelMetadata.ContainerType != null && !string.IsNullOrEmpty(context.ModelMetadata.PropertyName);
+        }
+    }
+
+    public class FluentValidationModelValidator : IModelValidator
+    {
+        private IValidator _validator;
+
+        public FluentValidationModelValidator(IValidator validator)
+        {
+            _validator = validator;
+        }
+
+        public IEnumerable<ModelValidationResult> Validate(ModelValidationContext context)
+        {
+            var model = context.Model;
+
+            var result = _validator.Validate(model);
+
+            return from error in result.Errors
+                   select new ModelValidationResult(error.PropertyName, error.ErrorMessage);
+
+        }
+
+        public bool IsRequired
+        {
+            get { return false; }
+        }
+    }
+}

--- a/src/FluentValidation.MvcCore/FluentValidationMvcCoreBuilderExtensions.cs
+++ b/src/FluentValidation.MvcCore/FluentValidationMvcCoreBuilderExtensions.cs
@@ -22,15 +22,12 @@ namespace FluentValidation.MvcCore
         /// <param name="assemblyToScan">assembly to scann for validators.</param>
         /// <param name="additionalAssembliesToScann">Additional assemblies to scann for validators.</param>
         /// <returns>The <see cref="IMvcBuilder"/>.</returns>
-        public static IMvcBuilder AddFluentValidation(this IMvcBuilder builder, Assembly assemblyToScan, params Assembly[] additionalAssembliesToScann)
-        {
-            if (builder == null)
-            {
+        public static IMvcBuilder AddFluentValidation(this IMvcBuilder builder, Assembly assemblyToScan, params Assembly[] additionalAssembliesToScann) {
+            if (builder == null) {
                 throw new ArgumentNullException(nameof(builder));
             }
 
-            if (assemblyToScan == null) 
-            {
+            if (assemblyToScan == null) {
                 throw new ArgumentNullException(nameof(assemblyToScan));
             }
 
@@ -38,25 +35,23 @@ namespace FluentValidation.MvcCore
             return builder;
         }
 
-        private static void AddFluentValidationServices(IServiceCollection services, IEnumerable<Assembly> assembliesToScann)
-        {
-             services.TryAddEnumerable(ServiceDescriptor.Transient<IConfigureOptions<MvcOptions>, FluentValidationMvcOptionsSetup>());
-             services.TryAddSingleton<IValidatorFactory, FluentValidationValidatorFactory>();
-             // add all validators..
-             var openGenericType = typeof(IValidator<>);
-            
-             var validators = from type in assembliesToScann.SelectMany(assembly => assembly.GetTypes())
-						let interfaces = type.GetInterfaces()
-						let genericInterfaces = interfaces.Where(i => i.GetTypeInfo().IsGenericType && i.GetGenericTypeDefinition() == openGenericType)
-						let matchingInterface = genericInterfaces.FirstOrDefault()
-						where matchingInterface != null
-						select new { InterfaceType = matchingInterface,  ValidatorType = type };
+        private static void AddFluentValidationServices(IServiceCollection services, IEnumerable<Assembly> assembliesToScann) {
+            services.TryAddEnumerable(ServiceDescriptor.Transient<IConfigureOptions<MvcOptions>, FluentValidationMvcOptionsSetup>());
+            services.TryAddSingleton<IValidatorFactory, FluentValidationValidatorFactory>();
+            // add all validators..
+            var openGenericType = typeof(IValidator<>);
 
-             foreach (var validator in validators) 
-             {
+            var validators = from type in assembliesToScann.SelectMany(assembly => assembly.GetTypes())
+                             let interfaces = type.GetInterfaces()
+                             let genericInterfaces = interfaces.Where(i => i.GetTypeInfo().IsGenericType && i.GetGenericTypeDefinition() == openGenericType)
+                             let matchingInterface = genericInterfaces.FirstOrDefault()
+                             where matchingInterface != null
+                             select new { InterfaceType = matchingInterface, ValidatorType = type };
+
+            foreach (var validator in validators) {
                 services.TryAddTransient(validator.InterfaceType, validator.ValidatorType);
-             }
+            }
         }
-        
+
     }
 }

--- a/src/FluentValidation.MvcCore/FluentValidationMvcCoreBuilderExtensions.cs
+++ b/src/FluentValidation.MvcCore/FluentValidationMvcCoreBuilderExtensions.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using FluentValidation;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+using System.Collections.Generic;
+
+namespace FluentValidation.MvcCore
+{
+    /// <summary>
+    /// Extensions for configuring MVC with FluentValidation using an <see cref="IMvcBuilder"/>.
+    /// </summary>
+    public static class FluentValidationMvcCoreBuilderExtensions
+    {
+        /// <summary>
+        /// Registers MVC FluentValidation.
+        /// </summary>
+        /// <param name="builder">The <see cref="IMvcBuilder"/>.</param>
+        /// <param name="assemblyToScan">assembly to scann for validators.</param>
+        /// <param name="additionalAssembliesToScann">Additional assemblies to scann for validators.</param>
+        /// <returns>The <see cref="IMvcBuilder"/>.</returns>
+        public static IMvcBuilder AddFluentValidation(this IMvcBuilder builder, Assembly assemblyToScan, params Assembly[] additionalAssembliesToScann)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            if (assemblyToScan == null) 
+            {
+                throw new ArgumentNullException(nameof(assemblyToScan));
+            }
+
+            AddFluentValidationServices(builder.Services, new[] { assemblyToScan }.Concat(additionalAssembliesToScann));
+            return builder;
+        }
+
+        private static void AddFluentValidationServices(IServiceCollection services, IEnumerable<Assembly> assembliesToScann)
+        {
+             services.TryAddEnumerable(ServiceDescriptor.Transient<IConfigureOptions<MvcOptions>, FluentValidationMvcOptionsSetup>());
+             services.TryAddSingleton<IValidatorFactory, FluentValidationValidatorFactory>();
+             // add all validators..
+             var openGenericType = typeof(IValidator<>);
+            
+             var validators = from type in assembliesToScann.SelectMany(assembly => assembly.GetTypes())
+						let interfaces = type.GetInterfaces()
+						let genericInterfaces = interfaces.Where(i => i.GetTypeInfo().IsGenericType && i.GetGenericTypeDefinition() == openGenericType)
+						let matchingInterface = genericInterfaces.FirstOrDefault()
+						where matchingInterface != null
+						select new { InterfaceType = matchingInterface,  ValidatorType = type };
+
+             foreach (var validator in validators) 
+             {
+                services.TryAddTransient(validator.InterfaceType, validator.ValidatorType);
+             }
+        }
+        
+    }
+}

--- a/src/FluentValidation.MvcCore/FluentValidationMvcOptionsSetup.cs
+++ b/src/FluentValidation.MvcCore/FluentValidationMvcOptionsSetup.cs
@@ -1,0 +1,26 @@
+using System;
+using FluentValidation;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace FluentValidation.MvcCore
+{
+    /// <summary>
+    /// Sets up default options for <see cref="MvcOptions"/>.
+    /// </summary>
+    public class FluentValidationMvcOptionsSetup : ConfigureOptions<MvcOptions>
+    {
+        public FluentValidationMvcOptionsSetup(IServiceProvider serviceProvider)
+            : base(options => ConfigureMvc(options, serviceProvider))
+        {
+        }
+
+        public static void ConfigureMvc(MvcOptions options, IServiceProvider serviceProvider)
+        {
+           var validatorFactory = serviceProvider.GetService<IValidatorFactory>();
+            
+            options.ModelValidatorProviders.Add(new FluentValidationModelValidatorProvider(validatorFactory));
+        }
+    }
+}

--- a/src/FluentValidation.MvcCore/FluentValidationMvcOptionsSetup.cs
+++ b/src/FluentValidation.MvcCore/FluentValidationMvcOptionsSetup.cs
@@ -12,14 +12,12 @@ namespace FluentValidation.MvcCore
     public class FluentValidationMvcOptionsSetup : ConfigureOptions<MvcOptions>
     {
         public FluentValidationMvcOptionsSetup(IServiceProvider serviceProvider)
-            : base(options => ConfigureMvc(options, serviceProvider))
-        {
+            : base(options => ConfigureMvc(options, serviceProvider)) {
         }
 
-        public static void ConfigureMvc(MvcOptions options, IServiceProvider serviceProvider)
-        {
-           var validatorFactory = serviceProvider.GetService<IValidatorFactory>();
-            
+        public static void ConfigureMvc(MvcOptions options, IServiceProvider serviceProvider) {
+            var validatorFactory = serviceProvider.GetService<IValidatorFactory>();
+
             options.ModelValidatorProviders.Add(new FluentValidationModelValidatorProvider(validatorFactory));
         }
     }

--- a/src/FluentValidation.MvcCore/FluentValidationValidatorFactory.cs
+++ b/src/FluentValidation.MvcCore/FluentValidationValidatorFactory.cs
@@ -5,7 +5,7 @@ namespace FluentValidation.MvcCore
 {
     public class FluentValidationValidatorFactory : ValidatorFactoryBase
     {
-       private readonly IServiceProvider _Container;
+        private readonly IServiceProvider _Container;
         public FluentValidationValidatorFactory(IServiceProvider container) {
             _Container = container;
         }

--- a/src/FluentValidation.MvcCore/FluentValidationValidatorFactory.cs
+++ b/src/FluentValidation.MvcCore/FluentValidationValidatorFactory.cs
@@ -1,0 +1,16 @@
+using System;
+using FluentValidation;
+
+namespace FluentValidation.MvcCore
+{
+    public class FluentValidationValidatorFactory : ValidatorFactoryBase
+    {
+       private readonly IServiceProvider _Container;
+        public FluentValidationValidatorFactory(IServiceProvider container) {
+            _Container = container;
+        }
+        public override IValidator CreateInstance(Type validatorType) {
+            return _Container.GetService(validatorType) as IValidator;
+        }
+    }
+}

--- a/src/FluentValidation.MvcCore/Properties/AssemblyInfo.cs
+++ b/src/FluentValidation.MvcCore/Properties/AssemblyInfo.cs
@@ -1,0 +1,19 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("FluentValidation.MvcCore")]
+[assembly: AssemblyTrademark("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("c8c80107-125a-4d48-9dda-f8f388c0e507")]

--- a/src/FluentValidation.MvcCore/project.json
+++ b/src/FluentValidation.MvcCore/project.json
@@ -1,0 +1,23 @@
+﻿{
+  "version": "1.0.0-*",
+  "description": "FluentValidation Integration with  AspNetCore",
+  "authors": [ "Jeremy Skinner" ],
+  "packExclude": [
+    "**.xproj",
+    "**.user",
+    "**.vspscc"
+  ],
+  "dependencies": {
+    "FluentValidation": "6.2.1",
+    "Microsoft.AspNetCore.Mvc.Core": "1.0.0-rc2-final"
+  },
+
+  "frameworks": {
+    "netstandard1.0": {
+      "imports": [
+        "dnxcore50",
+        "portable-net451+win81"
+      ]
+    }
+  }
+}

--- a/src/FluentValidation.NetStandard/FluentValidation.NetStandard.xproj
+++ b/src/FluentValidation.NetStandard/FluentValidation.NetStandard.xproj
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0.25123" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0.25123</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>40f21d92-9004-4d7e-af46-bf7f50a088eb</ProjectGuid>
+    <RootNamespace>FluentValidation.NetStandard</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>


### PR DESCRIPTION
I have added a new project FluentValidation.MvcCore. The integration project is working perfectly but in order to build it I had to change the `global.json` projects import Not to include the wrapper xproj. That brakes the NetStandard tests project. Maybe @jeremymeng could check it out.

Also the itegration with an MVC project is as easy as 

``` csharp
using FluentValidation.MvcCore;

public class Startup {
   ...

   public void ConfigureServices(IServiceCollection services) {

            services.AddMvc()
                    .AddFluentValidation(Assembly.GetEntryAssembly());
   }
}

```

Last but not least the validation plumbing in Mvc core is giving an extra option to mark a validator as `Reusable` upon discovery (check [FluentValidationModelValidatorProvider.cs](https://github.com/cleftheris/FluentValidation/blob/1e138c769d8e999cf15a9480849615c9f8d7deb7/src/FluentValidation.MvcCore/FluentValidationModelValidatorProvider.cs#L27)). This flag makes validators although registered as Transient with the DI to be treated (or not) as singletons. So I beleave that a custom `Attribute` or marker interface or base class could be used to trigger the flag on/off per validator.

This is related with #98 and could potentially help close it.
