### PR TITLE
Add support for length validation message grammar

### DIFF
--- a/src/FluentValidation.Tests/ExactLengthValidatorTester.cs
+++ b/src/FluentValidation.Tests/ExactLengthValidatorTester.cs
@@ -59,6 +59,30 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
+		public void When_the_validator_fails_the_error_message_should_be_grammatically_correct_for_single_length_rule_and_multi_length_input()
+		{
+			var validator = new TestValidator { v => v.RuleFor(x => x.Surname).Length(1) };
+			var result = validator.Validate(new Person() { Surname = ".." });
+			result.Errors.Single().ErrorMessage.ShouldEqual($"'Surname' must be 1 character in length. You entered 2 characters.");
+		}
+
+		[Fact]
+		public void When_the_validator_fails_the_error_message_should_be_grammatically_correct_for_multi_length_rule_and_single_length_input()
+		{
+			var validator = new TestValidator { v => v.RuleFor(x => x.Surname).Length(2) };
+			var result = validator.Validate(new Person() { Surname = "." });
+			result.Errors.Single().ErrorMessage.ShouldEqual($"'Surname' must be 2 characters in length. You entered 1 character.");
+		}
+
+		[Fact]
+		public void When_the_validator_fails_the_error_message_should_be_grammatically_correct_for_multi_length_rule_and_multi_length_input()
+		{
+			var validator = new TestValidator { v => v.RuleFor(x => x.Surname).Length(2) };
+			var result = validator.Validate(new Person() { Surname = "..." });
+			result.Errors.Single().ErrorMessage.ShouldEqual($"'Surname' must be 2 characters in length. You entered 3 characters.");
+		}
+
+		[Fact]
 		public void Min_and_max_properties_should_be_set() {
 			var validator = new ExactLengthValidator(5);
 			validator.Min.ShouldEqual(5);

--- a/src/FluentValidation.Tests/LengthValidatorTests.cs
+++ b/src/FluentValidation.Tests/LengthValidatorTests.cs
@@ -121,6 +121,30 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
+		public void When_the_validator_fails_the_error_message_should_be_grammatically_correct_for_single_length_rule_and_multi_length_input()
+		{
+			var validator = new TestValidator { v => v.RuleFor(x => x.Surname).Length(0, 1) };
+			var result = validator.Validate(new Person() { Surname = ".." });
+			result.Errors.Single().ErrorMessage.ShouldEqual($"'Surname' must be between 0 and 1 character. You entered 2 characters.");
+		}
+
+		[Fact]
+		public void When_the_validator_fails_the_error_message_should_be_grammatically_correct_for_multi_length_rule_and_single_length_input()
+		{
+			var validator = new TestValidator { v => v.RuleFor(x => x.Surname).Length(2, 3) };
+			var result = validator.Validate(new Person() { Surname = "." });
+			result.Errors.Single().ErrorMessage.ShouldEqual($"'Surname' must be between 2 and 3 characters. You entered 1 character.");
+		}
+
+		[Fact]
+		public void When_the_validator_fails_the_error_message_should_be_grammatically_correct_for_multi_length_rule_and_multi_length_input()
+		{
+			var validator = new TestValidator { v => v.RuleFor(x => x.Surname).Length(2, 3) };
+			var result = validator.Validate(new Person() { Surname = "...." });
+			result.Errors.Single().ErrorMessage.ShouldEqual($"'Surname' must be between 2 and 3 characters. You entered 4 characters.");
+		}
+
+		[Fact]
 		public void Min_and_max_properties_should_be_set() {
 			var validator = new LengthValidator(1, 5);
 			validator.Min.ShouldEqual(1);

--- a/src/FluentValidation/Resources/Messages.Designer.cs
+++ b/src/FluentValidation/Resources/Messages.Designer.cs
@@ -63,6 +63,24 @@ namespace FluentValidation.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to characters.
+        /// </summary>
+        public static string character_plural {
+            get {
+                return ResourceManager.GetString("character_plural", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to character.
+        /// </summary>
+        public static string character_singular {
+            get {
+                return ResourceManager.GetString("character_singular", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &apos;{PropertyName}&apos; is not a valid credit card number..
         /// </summary>
         public static string CreditCardError {
@@ -108,7 +126,7 @@ namespace FluentValidation.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{PropertyName}&apos; must be {MaxLength} characters in length. You entered {TotalLength} characters..
+        ///   Looks up a localized string similar to &apos;{PropertyName}&apos; must be {MaxLength} {MaxLengthCharacter} in length. You entered {TotalLength} {TotalLengthCharacter}..
         /// </summary>
         public static string exact_length_error {
             get {
@@ -153,7 +171,7 @@ namespace FluentValidation.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{PropertyName}&apos; must be between {MinLength} and {MaxLength} characters. You entered {TotalLength} characters..
+        ///   Looks up a localized string similar to &apos;{PropertyName}&apos; must be between {MinLength} and {MaxLength} {MaxLengthCharacter}. You entered {TotalLength} {TotalLengthCharacter}..
         /// </summary>
         public static string length_error {
             get {

--- a/src/FluentValidation/Resources/Messages.resx
+++ b/src/FluentValidation/Resources/Messages.resx
@@ -127,7 +127,7 @@
     <value>'{PropertyName}' must be greater than '{ComparisonValue}'.</value>
   </data>
   <data name="length_error" xml:space="preserve">
-    <value>'{PropertyName}' must be between {MinLength} and {MaxLength} characters. You entered {TotalLength} characters.</value>
+    <value>'{PropertyName}' must be between {MinLength} and {MaxLength} {MaxLengthCharacter}. You entered {TotalLength} {TotalLengthCharacter}.</value>
   </data>
   <data name="lessthanorequal_error" xml:space="preserve">
     <value>'{PropertyName}' must be less than or equal to '{ComparisonValue}'.</value>
@@ -154,7 +154,7 @@
     <value>'{PropertyName}' should be equal to '{ComparisonValue}'.</value>
   </data>
   <data name="exact_length_error" xml:space="preserve">
-    <value>'{PropertyName}' must be {MaxLength} characters in length. You entered {TotalLength} characters.</value>
+    <value>'{PropertyName}' must be {MaxLength} {MaxLengthCharacter} in length. You entered {TotalLength} {TotalLengthCharacter}.</value>
   </data>
   <data name="inclusivebetween_error" xml:space="preserve">
     <value>'{PropertyName}' must be between {From} and {To}. You entered {Value}.</value>
@@ -176,5 +176,11 @@
   </data>
   <data name="enum_error" xml:space="preserve">
     <value>'{PropertyName}' has a range of values which does not include '{PropertyValue}'.</value>
+  </data>
+  <data name="character_plural" xml:space="preserve">
+    <value>characters</value>
+  </data>
+  <data name="character_singular" xml:space="preserve">
+    <value>character</value>
   </data>
 </root>

--- a/src/FluentValidation/Validators/LengthValidator.cs
+++ b/src/FluentValidation/Validators/LengthValidator.cs
@@ -65,7 +65,16 @@ namespace FluentValidation.Validators {
 				context.MessageFormatter
 					.AppendArgument("MinLength", Min)
 					.AppendArgument("MaxLength", Max)
-					.AppendArgument("TotalLength", length);
+					.AppendArgument("TotalLength", length)
+					.AppendArgument("MinLengthCharacter", Min == 1
+						? Messages.character_singular
+						: Messages.character_plural)
+					.AppendArgument("MaxLengthCharacter", Max == 1
+						? Messages.character_singular
+						: Messages.character_plural)
+					.AppendArgument("TotalLengthCharacter", length == 1
+						? Messages.character_singular
+						: Messages.character_plural);
 
 				return false;
 			}


### PR DESCRIPTION
Previous behavior uses fixed grammar and does not make sense with certain numerical combinations (i.e. 1 => characters vs. 1 => character).

Only provided English-version of resource file. There is no associated issue with this PR. It is just something I encountered while using the library.
