### PR TITLE
Tweaks to the FluentValidation solution

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+# top-most EditorConfig file
+root = true
+
+[*.cs]
+indent_style = tab
+
+[*.{nuspec,config}]
+indent_style = space
+indent_size = 2

--- a/.nuget/NuGet.Config
+++ b/.nuget/NuGet.Config
@@ -3,4 +3,7 @@
   <solution>
     <add key="disableSourceControlIntegration" value="true" />
   </solution>
+  <packageSources>
+    <add key="NuGet.org" value="https://nuget.org/api/v2/" />
+  </packageSources>
 </configuration>

--- a/FluentValidation.sln
+++ b/FluentValidation.sln
@@ -5,6 +5,7 @@ VisualStudioVersion = 14.0.25123.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{3906F280-A567-4AD7-A0EF-7253E95E7852}"
 	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
 		Changelog.txt = Changelog.txt
 		FluentValidation.snk = FluentValidation.snk
 		src\FluentValidation.Tests-vnext\global.json = src\FluentValidation.Tests-vnext\global.json


### PR DESCRIPTION
Hi

This pull request contains two commits.

1. Define official NuGet package source in NuGet.config, instead of falling back to what's configured in Visual Studio.
2. Make use of [EditorConfig](http://editorconfig.org/) to define indentation rules. EditorConfig are used in many other OSS projects, including CoreCLR.

Andreas