### PR TITLE
Support a pluggable join separator in the property chain.

### DIFF
--- a/src/FluentValidation/Internal/PropertyChain.cs
+++ b/src/FluentValidation/Internal/PropertyChain.cs
@@ -118,7 +118,7 @@ namespace FluentValidation.Internal {
 		/// Creates a string representation of a property chain.
 		/// </summary>
 		public override string ToString() {
-			return string.Join(".", memberNames.ToArray());
+			return string.Join(ValidatorOptions.PropertyChainSeparator, memberNames.ToArray());
 		}
 
 		/// <summary>

--- a/src/FluentValidation/ValidatorOptions.cs
+++ b/src/FluentValidation/ValidatorOptions.cs
@@ -35,6 +35,11 @@ namespace FluentValidation {
 		public static CascadeMode CascadeMode = CascadeMode.Continue;
 
 		/// <summary>
+		/// Default property chain separator
+		/// </summary>
+		public static string PropertyChainSeparator = ".";
+
+		/// <summary>
 		/// Default resource provider
 		/// </summary>
 		public static Type ResourceProviderType;


### PR DESCRIPTION
…ToString() implementation to use ValidatorOptions.PropertyChainSepartor to allow pluggable support of different join separators.