### PR TITLE
Added support for a custom async predicate validator

### DIFF
--- a/src/FluentValidation/DefaultValidatorExtensions.cs
+++ b/src/FluentValidation/DefaultValidatorExtensions.cs
@@ -376,7 +376,7 @@ namespace FluentValidation {
 		/// <returns></returns>
 		public static IRuleBuilderOptions<T, TProperty> MustAsync<T, TProperty>(this IRuleBuilder<T, TProperty> ruleBuilder, Func<T, TProperty, PropertyValidatorContext, CancellationToken, Task<bool>> predicate) {
 			predicate.Guard("Cannot pass a null predicate to Must.");
-			return ruleBuilder.SetValidator(new AsyncPredicateValidator((instance, property, propertyValidatorContext, cancel) => predicate((T) instance, (TProperty) property, propertyValidatorContext, cancel)));
+			return ruleBuilder.SetValidator(ValidatorOptions.AsyncValidatorFactory((instance, property, propertyValidatorContext, cancel) => predicate((T) instance, (TProperty) property, propertyValidatorContext, cancel)));
 		}
 
 		/// <summary>

--- a/src/FluentValidation/ValidatorOptions.cs
+++ b/src/FluentValidation/ValidatorOptions.cs
@@ -24,6 +24,7 @@ namespace FluentValidation {
 	using System.Linq.Expressions;
 	using System.Reflection;
 	using Internal;
+	using Validators;
 
 	/// <summary>
 	/// Validator runtime options
@@ -52,6 +53,8 @@ namespace FluentValidation {
 
 		private static Func<Type, MemberInfo, LambdaExpression, string> propertyNameResolver = DefaultPropertyNameResolver;
 		private static Func<Type, MemberInfo, LambdaExpression, string> displayNameResolver = DefaultDisplayNameResolver;
+		private static Func<AsyncPredicate, IPropertyValidator> asyncValidatorFactory = CreateAsyncValidator;
+
 
 		/// <summary>
 		/// Pluggable logic for resolving property names
@@ -59,6 +62,15 @@ namespace FluentValidation {
 		public static Func<Type, MemberInfo, LambdaExpression, string> PropertyNameResolver {
 			get { return propertyNameResolver; }
 			set { propertyNameResolver = value ?? DefaultPropertyNameResolver; }
+		}
+
+		/// <summary>
+		/// Pluggable logic for creating a custom async validator
+		/// </summary>
+		public static Func<AsyncPredicate, IPropertyValidator> AsyncValidatorFactory
+		{
+			get { return asyncValidatorFactory; }
+			set { asyncValidatorFactory = value ?? CreateAsyncValidator; }
 		}
 
 		/// <summary>
@@ -110,6 +122,10 @@ namespace FluentValidation {
 			}
 
 			return name;
+		}
+
+		static IPropertyValidator CreateAsyncValidator(AsyncPredicate predicate) {
+			return new AsyncPredicateValidator(predicate);
 		}
 	}
 

--- a/src/FluentValidation/Validators/AsyncPredicateValidator.cs
+++ b/src/FluentValidation/Validators/AsyncPredicateValidator.cs
@@ -6,18 +6,20 @@ namespace FluentValidation.Validators
 	using FluentValidation.Internal;
 	using FluentValidation.Resources;
 
+	public delegate Task<bool> AsyncPredicate(object instance, object property, PropertyValidatorContext propertyValidatorContext, CancellationToken cancelToken);
+
 	/// <summary>
 	/// Asynchronous custom validator
 	/// </summary>
 	public class AsyncPredicateValidator : AsyncValidatorBase
 	{
-		private readonly Func<object, object, PropertyValidatorContext, CancellationToken, Task<bool>> predicate;
+		private readonly AsyncPredicate predicate;
 
 		/// <summary>
 		/// Creates a new ASyncPredicateValidator
 		/// </summary>
 		/// <param name="predicate"></param>
-		public AsyncPredicateValidator(Func<object, object, PropertyValidatorContext, CancellationToken, Task<bool>> predicate)
+		public AsyncPredicateValidator(AsyncPredicate predicate)
 			: base(nameof(Messages.predicate_error), typeof(Messages))
 		{
 			predicate.Guard("A predicate must be specified.");


### PR DESCRIPTION
The reason behind this feature is that the current AsyncPredicateValidator can cause a deadlock when we define a MustAsync that is validated using the Validate method. The deadlock will occur only in a single threaded context (ie. Windows UI thread or ASP.NET request context). There is also an issue #81 opened for this problem. 
So with this feature we are able to define a custom async predicate validator that can avoid a deadlock. [HERE](https://gist.github.com/maca88/4f10ec3ac66dd313cef52f4556b0fdd1) is an example by using Nito.AsyncEx package.