### PR TITLE
Using Task.Run in AsyncValidatorBase to avoid deadlock

### DIFF
--- a/src/FluentValidation/Validators/AsyncValidatorBase.cs
+++ b/src/FluentValidation/Validators/AsyncValidatorBase.cs
@@ -18,7 +18,7 @@ namespace FluentValidation.Validators {
 		}
 
 		protected override bool IsValid(PropertyValidatorContext context) {
-			return IsValidAsync(context, new CancellationToken()).Result;
+			return Task.Run(() => IsValidAsync(context, new CancellationToken())).Result;
 		}
 
 		protected abstract override Task<bool> IsValidAsync(PropertyValidatorContext context, CancellationToken cancellation);


### PR DESCRIPTION
As I understand calling just ``Task.Result`` is unsafe and might cause a deadlock. Wrapping it with `Task.Run(() => ..).Result` is safe.