### PR TITLE
Support sync running async validations using one thread

### DIFF
--- a/src/FluentValidation.NetStandard/FluentValidation.NetStandard.csproj
+++ b/src/FluentValidation.NetStandard/FluentValidation.NetStandard.csproj
@@ -101,6 +101,9 @@
     <Compile Include="..\FluentValidation\Resources\StaticStringSource.cs">
       <Link>StaticStringSource.cs</Link>
     </Compile>
+    <Compile Include="..\FluentValidation\TaskHelpers\AsyncHelpers.cs">
+      <Link>AsyncHelpers.cs</Link>
+    </Compile>
     <Compile Include="..\FluentValidation\TaskHelpers\TaskHelpers.cs">
       <Link>TaskHelpers.cs</Link>
     </Compile>

--- a/src/FluentValidation.Portable/FluentValidation.Portable45.csproj
+++ b/src/FluentValidation.Portable/FluentValidation.Portable45.csproj
@@ -99,6 +99,9 @@
     <Compile Include="..\FluentValidation\Resources\StaticStringSource.cs">
       <Link>StaticStringSource.cs</Link>
     </Compile>
+    <Compile Include="..\FluentValidation\TaskHelpers\AsyncHelpers.cs">
+      <Link>AsyncHelpers.cs</Link>
+    </Compile>
     <Compile Include="..\FluentValidation\TaskHelpers\TaskHelpers.cs">
       <Link>TaskHelpers.cs</Link>
     </Compile>

--- a/src/FluentValidation.Portable46/FluentValidation.Portable46.csproj
+++ b/src/FluentValidation.Portable46/FluentValidation.Portable46.csproj
@@ -102,6 +102,9 @@
     <Compile Include="..\FluentValidation\Resources\StaticStringSource.cs">
       <Link>StaticStringSource.cs</Link>
     </Compile>
+    <Compile Include="..\FluentValidation\TaskHelpers\AsyncHelpers.cs">
+      <Link>AsyncHelpers.cs</Link>
+    </Compile>
     <Compile Include="..\FluentValidation\TaskHelpers\TaskHelpers.cs">
       <Link>TaskHelpers.cs</Link>
     </Compile>

--- a/src/FluentValidation/FluentValidation.csproj
+++ b/src/FluentValidation/FluentValidation.csproj
@@ -111,6 +111,7 @@
     <Compile Include="Resources\LazyStringSource.cs" />
     <Compile Include="Resources\LocalizedStringSource.cs" />
     <Compile Include="Resources\StaticStringSource.cs" />
+    <Compile Include="TaskHelpers\AsyncHelpers.cs" />
     <Compile Include="TaskHelpers\TaskHelpers.cs" />
     <Compile Include="TaskHelpers\TaskHelpersExtensions.cs" />
     <Compile Include="TestHelper\TestPropertyChain.cs" />

--- a/src/FluentValidation/TaskHelpers/AsyncHelpers.cs
+++ b/src/FluentValidation/TaskHelpers/AsyncHelpers.cs
@@ -1,0 +1,115 @@
+﻿
+
+namespace System.Threading.Tasks
+{
+	using Collections.Generic;
+	using Runtime.ExceptionServices;
+
+	/// <summary>
+	/// Implementation taken from http://stackoverflow.com/questions/5095183/how-would-i-run-an-async-taskt-method-synchronously/5097066#5097066
+	/// with modified exception throwing, so that the original stacktrace is preserverd by using ExceptionDispatchInfo.Capture
+	/// </summary>
+	internal static class AsyncHelpers {
+
+		/// <summary>
+		/// Execute's an async <see cref="T:System.Threading.Tasks.Task" /> method which has a void return value synchronously
+		/// </summary>
+		/// <param name="task"><see cref="T:System.Threading.Tasks.Task" /> method to execute</param>
+		public static void RunSync(Func<Task> task) {
+			var oldContext = SynchronizationContext.Current;
+			var synch = new ExclusiveSynchronizationContext();
+			SynchronizationContext.SetSynchronizationContext(synch);
+			synch.Post(async _ => {
+				try {
+					await task();
+				}
+				catch (Exception e) {
+					synch.InnerException = e;
+					throw;
+				}
+				finally {
+					synch.EndMessageLoop();
+				}
+			}, null);
+			synch.BeginMessageLoop();
+			SynchronizationContext.SetSynchronizationContext(oldContext);
+			if (synch.InnerException != null) {
+				ExceptionDispatchInfo.Capture(synch.InnerException).Throw();
+			}
+		}
+
+		/// <summary>
+		/// Execute's an async <see cref="T:System.Threading.Tasks.Task`1" /> method which has a T return type synchronously
+		/// </summary>
+		/// <typeparam name="T">Return Type</typeparam>
+		/// <param name="task"><see cref="T:System.Threading.Tasks.Task`1" /> method to execute</param>
+		/// <returns></returns>
+		public static T RunSync<T>(Func<Task<T>> task) {
+			var oldContext = SynchronizationContext.Current;
+			var synch = new ExclusiveSynchronizationContext();
+			SynchronizationContext.SetSynchronizationContext(synch);
+			var ret = default(T);
+			synch.Post(async _ => {
+				try {
+					ret = await task();
+				}
+				catch (Exception e) {
+					synch.InnerException = e;
+					throw;
+				}
+				finally {
+					synch.EndMessageLoop();
+				}
+			}, null);
+			synch.BeginMessageLoop();
+			SynchronizationContext.SetSynchronizationContext(oldContext);
+			if (synch.InnerException != null) {
+				ExceptionDispatchInfo.Capture(synch.InnerException).Throw();
+			}
+			return ret;
+		}
+
+		private class ExclusiveSynchronizationContext : SynchronizationContext {
+			private bool done;
+			public Exception InnerException { get; set; }
+			readonly AutoResetEvent workItemsWaiting = new AutoResetEvent(false);
+			readonly Queue<Tuple<SendOrPostCallback, object>> items = new Queue<Tuple<SendOrPostCallback, object>>();
+
+			public override void Send(SendOrPostCallback d, object state) {
+				throw new NotSupportedException("We cannot send to our same thread");
+			}
+
+			public override void Post(SendOrPostCallback d, object state) {
+				lock (items) {
+					items.Enqueue(Tuple.Create(d, state));
+				}
+				workItemsWaiting.Set();
+			}
+
+			public void EndMessageLoop() {
+				Post(_ => done = true, null);
+			}
+
+			public void BeginMessageLoop() {
+				while (!done) {
+					Tuple<SendOrPostCallback, object> task = null;
+					lock (items) {
+						if (items.Count > 0) {
+							task = items.Dequeue();
+						}
+					}
+					if (task != null) {
+						task.Item1(task.Item2);
+					}
+					else {
+						workItemsWaiting.WaitOne();
+					}
+				}
+			}
+
+			public override SynchronizationContext CreateCopy() {
+				return this;
+			}
+		}
+	}
+}

--- a/src/FluentValidation/Validators/AsyncValidatorBase.cs
+++ b/src/FluentValidation/Validators/AsyncValidatorBase.cs
@@ -18,7 +18,7 @@ namespace FluentValidation.Validators {
 		}
 
 		protected override bool IsValid(PropertyValidatorContext context) {
-			return Task.Run(() => IsValidAsync(context, new CancellationToken())).Result;
+			return AsyncHelpers.RunSync(() => IsValidAsync(context, new CancellationToken()));
 		}
 
 		protected abstract override Task<bool> IsValidAsync(PropertyValidatorContext context, CancellationToken cancellation);


### PR DESCRIPTION
Implementation taken from [HERE](http://stackoverflow.com/questions/5095183/how-would-i-run-an-async-taskt-method-synchronously/5097066#5097066). I did some minor modifications to preserve the original stacktrace by using ExceptionDispatchInfo.Capture.