### PR TITLE
Added support for custom validation context

### DIFF
--- a/src/FluentValidation.Mvc4/FluentValidationModelValidator.cs
+++ b/src/FluentValidation.Mvc4/FluentValidationModelValidator.cs
@@ -25,7 +25,7 @@ namespace FluentValidation.Mvc {
 			if (Metadata.Model != null) {
 				var selector = customizations.ToValidatorSelector();
 				var interceptor = customizations.GetInterceptor() ?? (validator as IValidatorInterceptor);
-				var context = new ValidationContext(Metadata.Model, new PropertyChain(), selector);
+				var context = ValidatorOptions.ValidationContextFactory.Get(Metadata.Model, new PropertyChain(), selector);
 
 				if(interceptor != null) {
 					// Allow the user to provide a customized context

--- a/src/FluentValidation.Mvc4/IValidatorInterceptor.cs
+++ b/src/FluentValidation.Mvc4/IValidatorInterceptor.cs
@@ -13,7 +13,7 @@ namespace FluentValidation.Mvc {
 		/// <param name="controllerContext">Controller Context</param>
 		/// <param name="validationContext">Validation Context</param>
 		/// <returns>Validation Context</returns>
-		ValidationContext BeforeMvcValidation(ControllerContext controllerContext, ValidationContext validationContext);
+		IValidationContext BeforeMvcValidation(ControllerContext controllerContext, IValidationContext validationContext);
 
 		/// <summary>
 		/// Invoked after MVC validation takes place which allows the result to be customized.
@@ -23,6 +23,6 @@ namespace FluentValidation.Mvc {
 		/// <param name="validationContext">Validation Context</param>
 		/// <param name="result">The result of validation.</param>
 		/// <returns>Validation Context</returns>
-		ValidationResult AfterMvcValidation(ControllerContext controllerContext, ValidationContext validationContext, ValidationResult result);
+		ValidationResult AfterMvcValidation(ControllerContext controllerContext, IValidationContext validationContext, ValidationResult result);
 	}
 }

--- a/src/FluentValidation.Mvc4/PropertyValidatorAdapters/FluentValidationPropertyValidator.cs
+++ b/src/FluentValidation.Mvc4/PropertyValidatorAdapters/FluentValidationPropertyValidator.cs
@@ -41,7 +41,7 @@ namespace FluentValidation.Mvc {
 					DisplayName = Rule == null ? null : Rule.DisplayName,
 				};
 
-				var fakeParentContext = new ValidationContext(container);
+				var fakeParentContext = ValidatorOptions.ValidationContextFactory.Get(container);
 				var context = new PropertyValidatorContext(fakeParentContext, fakeRule, Metadata.PropertyName);
 				var result = Validator.Validate(context);
 

--- a/src/FluentValidation.Tests.Mvc5/ModelBinderTester.cs
+++ b/src/FluentValidation.Tests.Mvc5/ModelBinderTester.cs
@@ -519,22 +519,22 @@ namespace FluentValidation.Tests.Mvc5 {
 		private class SimplePropertyInterceptor : IValidatorInterceptor {
 			readonly string[] properties = new[] { "Surname", "Forename" };
 
-			public ValidationContext BeforeMvcValidation(ControllerContext cc, ValidationContext context) {
+			public IValidationContext BeforeMvcValidation(ControllerContext cc, IValidationContext context) {
 				var newContext = context.Clone(selector: new MemberNameValidatorSelector(properties));
 				return newContext;
 			}
 
-			public ValidationResult AfterMvcValidation(ControllerContext cc, ValidationContext context, ValidationResult result) {
+			public ValidationResult AfterMvcValidation(ControllerContext cc, IValidationContext context, ValidationResult result) {
 				return result;
 			}
 		}
 
 		private class ClearErrorsInterceptor : IValidatorInterceptor {
-			public ValidationContext BeforeMvcValidation(ControllerContext cc, ValidationContext context) {
+			public IValidationContext BeforeMvcValidation(ControllerContext cc, IValidationContext context) {
 				return null;
 			}
 
-			public ValidationResult AfterMvcValidation(ControllerContext cc, ValidationContext context, ValidationResult result) {
+			public ValidationResult AfterMvcValidation(ControllerContext cc, IValidationContext context, ValidationResult result) {
 				return new ValidationResult();
 			}
 		}
@@ -553,11 +553,11 @@ namespace FluentValidation.Tests.Mvc5 {
 				RuleFor(x => x.Forename).NotEqual("foo");
 			}
 
-			public ValidationContext BeforeMvcValidation(ControllerContext controllerContext, ValidationContext validationContext) {
+			public IValidationContext BeforeMvcValidation(ControllerContext controllerContext, IValidationContext validationContext) {
 				return validationContext;
 			}
 
-			public ValidationResult AfterMvcValidation(ControllerContext controllerContext, ValidationContext validationContext, ValidationResult result) {
+			public ValidationResult AfterMvcValidation(ControllerContext controllerContext, IValidationContext validationContext, ValidationResult result) {
 				return new ValidationResult(); //empty errors
 			}
 		}

--- a/src/FluentValidation.WebApi/FluentValidationModelValidator.cs
+++ b/src/FluentValidation.WebApi/FluentValidationModelValidator.cs
@@ -37,7 +37,7 @@ namespace FluentValidation.WebApi
 		public override IEnumerable<ModelValidationResult> Validate(ModelMetadata metadata, object container) {
 			if (metadata.Model != null) {
 				var selector = ValidatorOptions.ValidatorSelectors.DefaultValidatorSelectorFactory();
-				var context = new ValidationContext(metadata.Model, new PropertyChain(), selector);
+				var context = ValidatorOptions.ValidationContextFactory.Get(metadata.Model, new PropertyChain(), selector);
 
 				var result = validator.Validate(context);
 

--- a/src/FluentValidation/DefaultValidationContextFactory.cs
+++ b/src/FluentValidation/DefaultValidationContextFactory.cs
@@ -1,0 +1,68 @@
+﻿#region License
+// Copyright (c) Jeremy Skinner (http://www.jeremyskinner.co.uk)
+// 
+// Licensed under the Apache License, Version 2.0 (the "License"); 
+// you may not use this file except in compliance with the License. 
+// You may obtain a copy of the License at 
+// 
+// http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS, 
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+// 
+// The latest version of this file can be found at https://github.com/jeremyskinner/FluentValidation
+#endregion
+
+namespace FluentValidation {
+	using Internal;
+
+	/// <summary>
+	/// The default implementation for the validation context creation
+	/// </summary>
+	public class DefaultValidationContextFactory : IValidationContextFactory {
+
+		/// <summary>
+		/// Gets the validation context for the specified type.
+		/// </summary>
+		/// <typeparam name="T"></typeparam>
+		/// <param name="instanceToValidate">The instance to validate</param>
+		/// <param name="propertyChain">The chain of properties</param>
+		/// <param name="validatorSelector">The rule selector</param>
+		public virtual IValidationContext<T> Get<T>(T instanceToValidate, PropertyChain propertyChain, IValidatorSelector validatorSelector) {
+			return new ValidationContext<T>(instanceToValidate, propertyChain, validatorSelector);
+		}
+
+		/// <summary>
+		/// Gets the validation context for the specified type.
+		/// </summary>
+		/// <typeparam name="T"></typeparam>
+		/// <param name="instanceToValidate">The instance to validate</param>
+		/// <param name="propertyChain">The chain of properties</param>
+		/// <param name="validatorSelector">The rule selector</param>
+		/// <param name="isChildContext"></param>
+		public IValidationContext<T> Get<T>(T instanceToValidate, PropertyChain propertyChain, IValidatorSelector validatorSelector, bool isChildContext) {
+			return new ValidationContext<T>(instanceToValidate, propertyChain, validatorSelector, isChildContext);
+		}
+
+		/// <summary>
+		/// Gets the validation context for the specified object.
+		/// </summary>
+		/// <param name="instanceToValidate">The instance to validate</param>
+		/// <param name="propertyChain">The chain of properties</param>
+		/// <param name="validatorSelector">The rule selector</param>
+		public virtual IValidationContext Get(object instanceToValidate, PropertyChain propertyChain, IValidatorSelector validatorSelector) {
+			return new ValidationContext(instanceToValidate, propertyChain, validatorSelector);
+		}
+
+		/// <summary>
+		/// Gets the validation context for the specified object.
+		/// </summary>
+		/// <param name="instanceToValidate">The instance to validate</param>
+		public virtual IValidationContext Get(object instanceToValidate) {
+			return new ValidationContext(instanceToValidate);
+		}
+	}
+}

--- a/src/FluentValidation/DefaultValidatorExtensions.cs
+++ b/src/FluentValidation/DefaultValidatorExtensions.cs
@@ -807,7 +807,7 @@ namespace FluentValidation {
 		/// <returns>A ValidationResult object containing any validation failures</returns>
 		public static ValidationResult Validate<T>(this IValidator<T> validator, T instance, params Expression<Func<T, object>>[] propertyExpressions) {
 			var selector = ValidatorOptions.ValidatorSelectors.MemberNameValidatorSelectorFactory(MemberNameValidatorSelector.MemberNamesFromExpressions(propertyExpressions));
-			var context = new ValidationContext<T>(instance, new PropertyChain(), selector);
+			var context = ValidatorOptions.ValidationContextFactory.Get(instance, new PropertyChain(), selector);
 			return validator.Validate(context);
 		}
 
@@ -819,7 +819,7 @@ namespace FluentValidation {
 		/// <param name="properties">The names of the properties to validate.</param>
 		/// <returns>A ValidationResult object containing any validation failures.</returns>
 		public static ValidationResult Validate<T>(this IValidator<T> validator, T instance, params string[] properties) {
-			var context = new ValidationContext<T>(instance, new PropertyChain(), ValidatorOptions.ValidatorSelectors.MemberNameValidatorSelectorFactory(properties));
+			var context = ValidatorOptions.ValidationContextFactory.Get(instance, new PropertyChain(), ValidatorOptions.ValidatorSelectors.MemberNameValidatorSelectorFactory(properties));
 			return validator.Validate(context);
 		}
 
@@ -846,7 +846,7 @@ namespace FluentValidation {
 				selector = ValidatorOptions.ValidatorSelectors.RulesetValidatorSelectorFactory(ruleSetNames);
 			} 
 
-			var context = new ValidationContext<T>(instance, new PropertyChain(), selector);
+			var context = ValidatorOptions.ValidationContextFactory.Get(instance, new PropertyChain(), selector);
 			return validator.Validate(context);
 		}
 
@@ -859,7 +859,7 @@ namespace FluentValidation {
 		/// <returns>A ValidationResult object containing any validation failures</returns>
 		public static Task<ValidationResult> ValidateAsync<T>(this IValidator<T> validator, T instance, params Expression<Func<T, object>>[] propertyExpressions) {
 			var selector = ValidatorOptions.ValidatorSelectors.MemberNameValidatorSelectorFactory(MemberNameValidatorSelector.MemberNamesFromExpressions(propertyExpressions));
-			var context = new ValidationContext<T>(instance, new PropertyChain(), selector);
+			var context = ValidatorOptions.ValidationContextFactory.Get(instance, new PropertyChain(), selector);
 			return validator.ValidateAsync(context);
 		}
 
@@ -871,7 +871,7 @@ namespace FluentValidation {
 		/// <param name="properties">The names of the properties to validate.</param>
 		/// <returns>A ValidationResult object containing any validation failures.</returns>
 		public static Task<ValidationResult> ValidateAsync<T>(this IValidator<T> validator, T instance, params string[] properties) {
-			var context = new ValidationContext<T>(instance, new PropertyChain(), ValidatorOptions.ValidatorSelectors.MemberNameValidatorSelectorFactory(properties));
+			var context = ValidatorOptions.ValidationContextFactory.Get(instance, new PropertyChain(), ValidatorOptions.ValidatorSelectors.MemberNameValidatorSelectorFactory(properties));
 			return validator.ValidateAsync(context);
 		}
 
@@ -898,7 +898,7 @@ namespace FluentValidation {
 				selector = ValidatorOptions.ValidatorSelectors.RulesetValidatorSelectorFactory(ruleSetNames);
 			}
 
-			var context = new ValidationContext<T>(instance, new PropertyChain(), selector);
+			var context = ValidatorOptions.ValidationContextFactory.Get(instance, new PropertyChain(), selector);
 			return validator.ValidateAsync(context);
 		}
 

--- a/src/FluentValidation/FluentValidation.csproj
+++ b/src/FluentValidation/FluentValidation.csproj
@@ -99,6 +99,8 @@
     <Compile Include="Internal\InstanceCache.cs" />
     <Compile Include="Internal\RulesetValidatorSelector.cs" />
     <Compile Include="Internal\TrackingCollection.cs" />
+    <Compile Include="IValidationContext.cs" />
+    <Compile Include="IValidationContextFactory.cs" />
     <Compile Include="IValidationRule.cs" />
     <Compile Include="Internal\MemberNameValidatorSelector.cs" />
     <Compile Include="Internal\MessageFormatter.cs" />
@@ -133,6 +135,7 @@
     <Compile Include="IValidatorFactory.cs" />
     <Compile Include="TestHelper\ValidationTestException.cs" />
     <Compile Include="TestHelper\ValidatorTestExtensions.cs" />
+    <Compile Include="DefaultValidationContextFactory.cs" />
     <Compile Include="ValidationException.cs" />
     <Compile Include="ValidatorFactoryBase.cs" />
     <Compile Include="ValidatorOptions.cs" />

--- a/src/FluentValidation/IValidationContext.cs
+++ b/src/FluentValidation/IValidationContext.cs
@@ -1,0 +1,83 @@
+﻿#region License
+// Copyright (c) Jeremy Skinner (http://www.jeremyskinner.co.uk)
+// 
+// Licensed under the Apache License, Version 2.0 (the "License"); 
+// you may not use this file except in compliance with the License. 
+// You may obtain a copy of the License at 
+// 
+// http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS, 
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+// 
+// The latest version of this file can be found at https://github.com/jeremyskinner/FluentValidation
+#endregion
+
+namespace FluentValidation {
+	using Internal;
+
+	/// <summary>
+	/// Validation context
+	/// </summary>
+	/// <typeparam name="T"></typeparam>
+	public interface IValidationContext<out T> : IValidationContext {
+		/// <summary>
+		/// Object being validated
+		/// </summary>
+		new T InstanceToValidate { get; }
+	}
+
+	/// <summary>
+	/// Validation context
+	/// </summary>
+	public interface IValidationContext {
+		/// <summary>
+		/// Property chain
+		/// </summary>
+		PropertyChain PropertyChain { get; }
+
+		/// <summary>
+		/// Object being validated
+		/// </summary>
+		object InstanceToValidate { get; }
+
+		/// <summary>
+		/// Selector
+		/// </summary>
+		IValidatorSelector Selector { get; }
+
+		/// <summary>
+		/// Whether this is a child context
+		/// </summary>
+		bool IsChildContext { get; }
+
+		/// <summary>
+		/// Creates a new <see cref="IValidationContext" /> based on this one
+		/// </summary>
+		/// <param name="chain"></param>
+		/// <param name="instanceToValidate"></param>
+		/// <param name="selector"></param>
+		/// <returns></returns>
+		IValidationContext Clone(PropertyChain chain = null, object instanceToValidate = null, IValidatorSelector selector = null);
+
+		/// <summary>
+		/// Creates a new <see cref="IValidationContext{T}" /> ValidationContext based on this one
+		/// </summary>
+		/// <param name="chain"></param>
+		/// <param name="instanceToValidate"></param>
+		/// <param name="selector"></param>
+		/// <param name="isChildContext"></param>
+		/// <returns></returns>
+		IValidationContext<TType> Clone<TType>(PropertyChain chain = null, TType instanceToValidate = default(TType), IValidatorSelector selector = null, bool? isChildContext = null);
+
+		/// <summary>
+		/// Creates a new validation context for use with a child validator
+		/// </summary>
+		/// <param name="instanceToValidate"></param>
+		/// <returns></returns>
+		IValidationContext CloneForChildValidator(object instanceToValidate);
+	}
+}

--- a/src/FluentValidation/IValidationContextFactory.cs
+++ b/src/FluentValidation/IValidationContextFactory.cs
@@ -1,0 +1,59 @@
+﻿#region License
+// Copyright (c) Jeremy Skinner (http://www.jeremyskinner.co.uk)
+// 
+// Licensed under the Apache License, Version 2.0 (the "License"); 
+// you may not use this file except in compliance with the License. 
+// You may obtain a copy of the License at 
+// 
+// http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS, 
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+// 
+// The latest version of this file can be found at https://github.com/jeremyskinner/FluentValidation
+#endregion
+
+namespace FluentValidation {
+	using Internal;
+
+	/// <summary>
+	/// Gets a validation context for a particular type.
+	/// </summary>
+	public interface IValidationContextFactory {
+		/// <summary>
+		/// Gets the validation context for the specified type.
+		/// </summary>
+		/// <typeparam name="T"></typeparam>
+		/// <param name="instanceToValidate">The instance to validate</param>
+		/// <param name="propertyChain">The chain of properties</param>
+		/// <param name="validatorSelector">The rule selector</param>
+		IValidationContext<T> Get<T>(T instanceToValidate, PropertyChain propertyChain, IValidatorSelector validatorSelector);
+
+		/// <summary>
+		/// Gets the validation context for the specified type.
+		/// </summary>
+		/// <typeparam name="T"></typeparam>
+		/// <param name="instanceToValidate">The instance to validate</param>
+		/// <param name="propertyChain">The chain of properties</param>
+		/// <param name="validatorSelector">The rule selector</param>
+		/// <param name="isChildContext"></param>
+		IValidationContext<T> Get<T>(T instanceToValidate, PropertyChain propertyChain, IValidatorSelector validatorSelector, bool isChildContext);
+
+		/// <summary>
+		/// Gets the validation context for the specified object.
+		/// </summary>
+		/// <param name="instanceToValidate">The instance to validate</param>
+		/// <param name="propertyChain">The chain of properties</param>
+		/// <param name="validatorSelector">The rule selector</param>
+		IValidationContext Get(object instanceToValidate, PropertyChain propertyChain, IValidatorSelector validatorSelector);
+
+		/// <summary>
+		/// Gets the validation context for the specified object.
+		/// </summary>
+		/// <param name="instanceToValidate">The instance to validate</param>
+		IValidationContext Get(object instanceToValidate);
+	}
+}

--- a/src/FluentValidation/IValidationRule.cs
+++ b/src/FluentValidation/IValidationRule.cs
@@ -43,7 +43,7 @@ namespace FluentValidation {
 		/// </summary>
 		/// <param name="context">Validation Context</param>
 		/// <returns>A collection of validation failures</returns>
-		IEnumerable<ValidationFailure> Validate(ValidationContext context);
+		IEnumerable<ValidationFailure> Validate(IValidationContext context);
 
 		/// <summary>
 		/// Performs validation using a validation context and returns a collection of Validation Failures asynchronoulsy.
@@ -51,7 +51,7 @@ namespace FluentValidation {
 		/// <param name="context">Validation Context</param>
 		/// <param name="cancellation">Cancellation token</param>
 		/// <returns>A collection of validation failures</returns>
-		Task<IEnumerable<ValidationFailure>> ValidateAsync(ValidationContext context, CancellationToken cancellation);
+		Task<IEnumerable<ValidationFailure>> ValidateAsync(IValidationContext context, CancellationToken cancellation);
 
 		/// <summary>
 		/// Applies a condition to the rule

--- a/src/FluentValidation/IValidator.cs
+++ b/src/FluentValidation/IValidator.cs
@@ -74,7 +74,7 @@ namespace FluentValidation {
 		/// </summary>
 		/// <param name="context">A ValidationContext</param>
 		/// <returns>A ValidationResult object containy any validation failures.</returns>
-		ValidationResult Validate(ValidationContext context);
+		ValidationResult Validate(IValidationContext context);
 
 		/// <summary>
 		/// Validates the specified instance asynchronously.
@@ -82,7 +82,7 @@ namespace FluentValidation {
 		/// <param name="context">A ValidationContext</param>
 		/// <param name="cancellation">Cancellation token</param>
 		/// <returns>A ValidationResult object containy any validation failures.</returns>		
-		Task<ValidationResult> ValidateAsync(ValidationContext context, CancellationToken cancellation = new CancellationToken());
+		Task<ValidationResult> ValidateAsync(IValidationContext context, CancellationToken cancellation = new CancellationToken());
 
 		/// <summary>
 		/// Creates a hook to access various meta data properties

--- a/src/FluentValidation/Internal/CollectionPropertyRule.cs
+++ b/src/FluentValidation/Internal/CollectionPropertyRule.cs
@@ -61,7 +61,7 @@ namespace FluentValidation.Internal {
 		/// <param name="propertyName"></param>
 		/// <param name="cancellation"></param>
 		/// <returns></returns>
-		protected override Task<IEnumerable<ValidationFailure>> InvokePropertyValidatorAsync(ValidationContext context, IPropertyValidator validator, string propertyName, CancellationToken cancellation) {
+		protected override Task<IEnumerable<ValidationFailure>> InvokePropertyValidatorAsync(IValidationContext context, IPropertyValidator validator, string propertyName, CancellationToken cancellation) {
 
 			var propertyContext = new PropertyValidatorContext(context, this, propertyName);
 			var results = new List<ValidationFailure>();
@@ -104,7 +104,7 @@ namespace FluentValidation.Internal {
 		/// <param name="validator"></param>
 		/// <param name="propertyName"></param>
 		/// <returns></returns>
-		protected override IEnumerable<Results.ValidationFailure> InvokePropertyValidator(ValidationContext context, Validators.IPropertyValidator validator, string propertyName) {
+		protected override IEnumerable<Results.ValidationFailure> InvokePropertyValidator(IValidationContext context, Validators.IPropertyValidator validator, string propertyName) {
 			var propertyContext = new PropertyValidatorContext(context, this, propertyName);
 			var results = new List<ValidationFailure>();
 			var delegatingValidator = validator as IDelegatingValidator;

--- a/src/FluentValidation/Internal/DefaultValidatorSelector.cs
+++ b/src/FluentValidation/Internal/DefaultValidatorSelector.cs
@@ -28,7 +28,7 @@ namespace FluentValidation.Internal {
 		/// <param name="propertyPath">Property path (eg Customer.Address.Line1)</param>
 		/// <param name="context">Contextual information</param>
 		/// <returns>Whether or not the validator can execute.</returns>
-		public bool CanExecute(IValidationRule rule, string propertyPath, ValidationContext context) {
+		public bool CanExecute(IValidationRule rule, string propertyPath, IValidationContext context) {
 			// By default we ignore any rules part of a RuleSet.
 			if (!string.IsNullOrEmpty(rule.RuleSet)) return false;
 

--- a/src/FluentValidation/Internal/DelegateValidator.cs
+++ b/src/FluentValidation/Internal/DelegateValidator.cs
@@ -135,7 +135,7 @@ namespace FluentValidation.Internal {
 		}
 
 		Task<IEnumerable<ValidationFailure>> ValidateAsyncInternal(IValidationContext context, CancellationToken cancellation) {
-			var newContext = ValidatorOptions.ValidationContextFactory.Get((T) context.InstanceToValidate, context.PropertyChain, context.Selector);
+			var newContext = context.Clone<T>(isChildContext : false);
 			return ValidateAsync(newContext, cancellation);
 		}
 

--- a/src/FluentValidation/Internal/DelegateValidator.cs
+++ b/src/FluentValidation/Internal/DelegateValidator.cs
@@ -30,8 +30,8 @@ namespace FluentValidation.Internal {
 	/// </summary>
 	/// <typeparam name="T"></typeparam>
 	public class DelegateValidator<T> : IValidationRule {
-		private readonly Func<T, ValidationContext<T>, IEnumerable<ValidationFailure>> func;
-		private readonly Func<T, ValidationContext<T>, CancellationToken, Task<IEnumerable<ValidationFailure>>> asyncFunc;
+		private readonly Func<T, IValidationContext<T>, IEnumerable<ValidationFailure>> func;
+		private readonly Func<T, IValidationContext<T>, CancellationToken, Task<IEnumerable<ValidationFailure>>> asyncFunc;
 
 		// Work-around for reflection bug in .NET 4.5
 		static Func<object, bool> s_condition = x => true;
@@ -46,7 +46,7 @@ namespace FluentValidation.Internal {
 		/// <summary>
 		/// Creates a new DelegateValidator using the specified function to perform validation.
 		/// </summary>
-		public DelegateValidator(Func<T, ValidationContext<T>, IEnumerable<ValidationFailure>> func) {
+		public DelegateValidator(Func<T, IValidationContext<T>, IEnumerable<ValidationFailure>> func) {
 			this.func = func;
 			asyncFunc = (x, ctx, cancel) => TaskHelpers.RunSynchronously(() => this.func(x, ctx), cancel);
 		}
@@ -61,7 +61,7 @@ namespace FluentValidation.Internal {
 		/// <summary>
 		/// Creates a new DelegateValidator using the specified async function to perform validation.
 		/// </summary>
-		public DelegateValidator(Func<T, ValidationContext<T>, CancellationToken, Task<IEnumerable<ValidationFailure>>> asyncFunc) {
+		public DelegateValidator(Func<T, IValidationContext<T>, CancellationToken, Task<IEnumerable<ValidationFailure>>> asyncFunc) {
 			this.asyncFunc = asyncFunc;
 			func = (x, ctx) => Task.Factory.StartNew(() => this.asyncFunc(x, ctx, new CancellationToken())).Unwrap().Result;
 		}
@@ -78,7 +78,7 @@ namespace FluentValidation.Internal {
 		/// </summary>
 		/// <param name="context">Validation Context</param>
 		/// <returns>A collection of validation failures</returns>
-		public IEnumerable<ValidationFailure> Validate(ValidationContext<T> context) {
+		public IEnumerable<ValidationFailure> Validate(IValidationContext<T> context) {
 			return func(context.InstanceToValidate, context);
 		}
 
@@ -88,7 +88,7 @@ namespace FluentValidation.Internal {
 		/// <param name="context">Validation Context</param>
 		/// <param name="cancellation"></param>
 		/// <returns>A collection of validation failures</returns>
-		public Task<IEnumerable<ValidationFailure>> ValidateAsync(ValidationContext<T> context, CancellationToken cancellation) {
+		public Task<IEnumerable<ValidationFailure>> ValidateAsync(IValidationContext<T> context, CancellationToken cancellation) {
 			return asyncFunc(context.InstanceToValidate, context, cancellation);
 		}
 
@@ -104,13 +104,13 @@ namespace FluentValidation.Internal {
 		/// </summary>
 		/// <param name="context">Validation Context</param>
 		/// <returns>A collection of validation failures</returns>
-		public IEnumerable<ValidationFailure> Validate(ValidationContext context) {
+		public IEnumerable<ValidationFailure> Validate(IValidationContext context) {
 			if (!context.Selector.CanExecute(this, "", context) || !condition(context.InstanceToValidate) ||
 				(asyncCondition != null && !asyncCondition(context.InstanceToValidate).Result)) {
 				return Enumerable.Empty<ValidationFailure>();
 			}
 
-			var newContext = new ValidationContext<T>((T) context.InstanceToValidate, context.PropertyChain, context.Selector);
+			var newContext = context.Clone<T>(isChildContext : false);
 			return Validate(newContext);
 		}
 
@@ -120,7 +120,7 @@ namespace FluentValidation.Internal {
 		/// <param name="context">Validation Context</param>
 		/// <param name="cancellation"></param>
 		/// <returns>A collection of validation failures</returns>
-		public Task<IEnumerable<ValidationFailure>> ValidateAsync(ValidationContext context, CancellationToken cancellation) {
+		public Task<IEnumerable<ValidationFailure>> ValidateAsync(IValidationContext context, CancellationToken cancellation) {
 			if (!context.Selector.CanExecute(this, "", context) || !condition(context.InstanceToValidate)) {
 				return TaskHelpers.FromResult(Enumerable.Empty<ValidationFailure>());
 			}
@@ -134,8 +134,8 @@ namespace FluentValidation.Internal {
 					runSynchronously: true, cancellationToken: cancellation);
 		}
 
-		Task<IEnumerable<ValidationFailure>> ValidateAsyncInternal(ValidationContext context, CancellationToken cancellation) {
-			var newContext = new ValidationContext<T>((T) context.InstanceToValidate, context.PropertyChain, context.Selector);
+		Task<IEnumerable<ValidationFailure>> ValidateAsyncInternal(IValidationContext context, CancellationToken cancellation) {
+			var newContext = ValidatorOptions.ValidationContextFactory.Get((T) context.InstanceToValidate, context.PropertyChain, context.Selector);
 			return ValidateAsync(newContext, cancellation);
 		}
 

--- a/src/FluentValidation/Internal/IValidatorSelector.cs
+++ b/src/FluentValidation/Internal/IValidatorSelector.cs
@@ -29,6 +29,6 @@ namespace FluentValidation.Internal {
 		/// <param name="propertyPath">Property path (eg Customer.Address.Line1)</param>
 		/// <param name="context">Contextual information</param>
 		/// <returns>Whether or not the validator can execute.</returns>
-		bool CanExecute(IValidationRule rule, string propertyPath, ValidationContext context);
+		bool CanExecute(IValidationRule rule, string propertyPath, IValidationContext context);
 	}
 }

--- a/src/FluentValidation/Internal/MemberNameValidatorSelector.cs
+++ b/src/FluentValidation/Internal/MemberNameValidatorSelector.cs
@@ -42,7 +42,7 @@ namespace FluentValidation.Internal {
 		/// <param name="propertyPath">Property path (eg Customer.Address.Line1)</param>
 		/// <param name="context">Contextual information</param>
 		/// <returns>Whether or not the validator can execute.</returns>
-		public bool CanExecute (IValidationRule rule, string propertyPath, ValidationContext context) {
+		public bool CanExecute (IValidationRule rule, string propertyPath, IValidationContext context) {
 			// Validator selector only applies to the top level.
  			// If we're running in a child context then this means that the child validator has already been selected
 			// Because of this, we assume that the rule should continue (ie if the parent rule is valid, all children are valid)

--- a/src/FluentValidation/Internal/PropertyRule.cs
+++ b/src/FluentValidation/Internal/PropertyRule.cs
@@ -221,7 +221,7 @@ namespace FluentValidation.Internal {
 		/// </summary>
 		/// <param name="context">Validation Context</param>
 		/// <returns>A collection of validation failures</returns>
-		public virtual IEnumerable<ValidationFailure> Validate(ValidationContext context) {
+		public virtual IEnumerable<ValidationFailure> Validate(IValidationContext context) {
 			string displayName = GetDisplayName();
 
 			if (PropertyName == null && displayName == null) {
@@ -279,7 +279,7 @@ namespace FluentValidation.Internal {
 		/// <param name="context">Validation Context</param>
 		/// <param name="cancellation"></param>
 		/// <returns>A collection of validation failures</returns>
-		public Task<IEnumerable<ValidationFailure>> ValidateAsync(ValidationContext context, CancellationToken cancellation) {
+		public Task<IEnumerable<ValidationFailure>> ValidateAsync(IValidationContext context, CancellationToken cancellation) {
 			try {
 				var displayName = GetDisplayName();
 
@@ -369,14 +369,14 @@ namespace FluentValidation.Internal {
 		/// <param name="propertyName"></param>
 		/// <param name="cancellation"></param>
 		/// <returns></returns>
-		protected virtual Task<IEnumerable<ValidationFailure>> InvokePropertyValidatorAsync(ValidationContext context, IPropertyValidator validator, string propertyName, CancellationToken cancellation) {
+		protected virtual Task<IEnumerable<ValidationFailure>> InvokePropertyValidatorAsync(IValidationContext context, IPropertyValidator validator, string propertyName, CancellationToken cancellation) {
 			return validator.ValidateAsync(new PropertyValidatorContext(context, this, propertyName), cancellation);
 		}
 
 		/// <summary>
 		/// Invokes a property validator using the specified validation context.
 		/// </summary>
-		protected virtual IEnumerable<ValidationFailure> InvokePropertyValidator(ValidationContext context, IPropertyValidator validator, string propertyName) {
+		protected virtual IEnumerable<ValidationFailure> InvokePropertyValidator(IValidationContext context, IPropertyValidator validator, string propertyName) {
 			var propertyContext = new PropertyValidatorContext(context, this, propertyName);
 			return validator.Validate(propertyContext);
 		}

--- a/src/FluentValidation/Internal/RulesetValidatorSelector.cs
+++ b/src/FluentValidation/Internal/RulesetValidatorSelector.cs
@@ -31,7 +31,7 @@ namespace FluentValidation.Internal {
 		/// <param name="propertyPath">Property path (eg Customer.Address.Line1)</param>
 		/// <param name="context">Contextual information</param>
 		/// <returns>Whether or not the validator can execute.</returns>
-		public bool CanExecute(IValidationRule rule, string propertyPath, ValidationContext context) {
+		public bool CanExecute(IValidationRule rule, string propertyPath, IValidationContext context) {
 			if (string.IsNullOrEmpty(rule.RuleSet) && rulesetsToExecute.Length > 0) {
 				if (IsIncludeRule(rule)) {
 					return true;

--- a/src/FluentValidation/ValidatorOptions.cs
+++ b/src/FluentValidation/ValidatorOptions.cs
@@ -61,6 +61,16 @@ namespace FluentValidation {
 			set { propertyNameResolver = value ?? DefaultPropertyNameResolver; }
 		}
 
+		private static IValidationContextFactory validationContextFactory = new DefaultValidationContextFactory();
+		/// <summary>
+		/// Pluggable logic for the creation of a validation context
+		/// </summary>
+		public static IValidationContextFactory ValidationContextFactory
+		{
+			get { return validationContextFactory; }
+			set { validationContextFactory = value ?? validationContextFactory; }
+		}
+
 		/// <summary>
 		/// Pluggable logic for resolving display names
 		/// </summary>

--- a/src/FluentValidation/Validators/ChildCollectionValidatorAdaptor.cs
+++ b/src/FluentValidation/Validators/ChildCollectionValidatorAdaptor.cs
@@ -83,7 +83,7 @@ namespace FluentValidation.Validators {
 
 		TResult ValidateInternal<TResult>(
 			PropertyValidatorContext context,
-			Func<IEnumerable<Tuple<ValidationContext, IValidator>>, TResult> validatorApplicator,
+			Func<IEnumerable<Tuple<IValidationContext, IValidator>>, TResult> validatorApplicator,
 			TResult emptyResult
 		) {
 			var collection = context.PropertyValue as IEnumerable;

--- a/src/FluentValidation/Validators/ChildValidatorAdaptor.cs
+++ b/src/FluentValidation/Validators/ChildValidatorAdaptor.cs
@@ -46,7 +46,7 @@ namespace FluentValidation.Validators {
 			);
 		}
 
-		private TResult ValidateInternal<TResult>(PropertyValidatorContext context, Func<ValidationContext, IValidator, TResult> validationApplicator, TResult emptyResult) {
+		private TResult ValidateInternal<TResult>(PropertyValidatorContext context, Func<IValidationContext, IValidator, TResult> validationApplicator, TResult emptyResult) {
 			var instanceToValidate = context.PropertyValue;
 
 			if (instanceToValidate == null) {
@@ -69,7 +69,7 @@ namespace FluentValidation.Validators {
 			return validatorProvider(context.Instance);
 		}
 
-		protected ValidationContext CreateNewValidationContextForChildValidator(object instanceToValidate, PropertyValidatorContext context) {
+		protected IValidationContext CreateNewValidationContextForChildValidator(object instanceToValidate, PropertyValidatorContext context) {
 			var newContext = context.ParentContext.CloneForChildValidator(instanceToValidate);
 			newContext.PropertyChain.Add(context.Rule.PropertyName);
 			return newContext;

--- a/src/FluentValidation/Validators/PropertyValidatorContext.cs
+++ b/src/FluentValidation/Validators/PropertyValidatorContext.cs
@@ -28,7 +28,7 @@ namespace FluentValidation.Validators {
 		private readonly MessageFormatter messageFormatter = new MessageFormatter();
 		private readonly Lazy<object> propertyValueContainer;
 
-		public ValidationContext ParentContext { get; private set; }
+		public IValidationContext ParentContext { get; private set; }
 		public PropertyRule Rule { get; private set; }
 		public string PropertyName { get; private set; }
 		
@@ -50,7 +50,7 @@ namespace FluentValidation.Validators {
 			get { return propertyValueContainer.Value; }
 		}
 
-		public PropertyValidatorContext(ValidationContext parentContext, PropertyRule rule, string propertyName) {
+		public PropertyValidatorContext(IValidationContext parentContext, PropertyRule rule, string propertyName) {
 			ParentContext = parentContext;
 			Rule = rule;
 			PropertyName = propertyName;
@@ -58,7 +58,7 @@ namespace FluentValidation.Validators {
 		}
 
 
-		public PropertyValidatorContext(ValidationContext parentContext, PropertyRule rule, string propertyName, object propertyValue)
+		public PropertyValidatorContext(IValidationContext parentContext, PropertyRule rule, string propertyName, object propertyValue)
 		{
 			ParentContext = parentContext;
 			Rule = rule;


### PR DESCRIPTION
The reason to have a custom validation context is to increase the validation performace when validating a collection of models for which we need to trigger a database query to do a check (ie. code existance in the db). With the current FV we cannot pass a custom data to a validation rule in order to avoid a query. Lets see an example:
```
public class ParentEntity {
	public List<ChildEntity> Children { get; set; } = new List<ChildEntity>();
}

public class ChildEntity {
	public string Code { get; set; }
}

public class ParentEntityValidator : AbstractValidator<ParentEntity> {
	public ParentEntityValidator(ISession dbSession) {
		RuleFor(o => o.Children).SetCollectionValidator(new ChildEntityValidator(dbSession));
	}
}

public class ChildEntityValidator : AbstractValidator<ChildEntity> {
	public ChildEntityValidator(ISession dbSession) {
		RuleFor(m => m.Code)
			.Must((entity, code, ctx) => {
				return dbSession.Query<ChildEntity>().Any(o => o.Code == code);
			})
			.WithMessage("Code does not exist in the database");
	}
}
```
In the above example we need to trigger a query for each child which is not scalable. This validation could be improved by fetching the children codes from the database with one query and store the result in a custom context:
```
static void Main(string[] args) {
	...
	// Create entities to validate 
	var parent = new ParentEntity();
	for (var i = 0; i < 500; i++) {
		parent.Children.Add(new ChildEntity {Code = $"Code{i}"});

	}
	
	// Get all children codes that we will use in the query
	var childCodes = parent.Children.Select(o => o.Code).ToList();
	// Execute a query that will find all existing codes from the database
	var existingCodes = new HashSet<string>(dbSession.Query<ChildEntity>().Where(o => childCodes.Contains(o)));

	// Create a custom validation context with the fetched existing codes
	var rootCtx = new RootValidationContext<ParentEntity, CachedData>(parent, new CachedData(existingCodes));

	// Validate the parent
	var result = new ParentEntityValidator().Validate(rootCtx);
}

// New child validator
public class ChildEntityValidator : AbstractValidator<ChildEntity> {
	public ChildEntityValidator() {
		RuleFor(m => m.Code)
			.Must((entity, code, ctx) => {
				// Get the cached existing codes in order to avoid a db query
				var cctx = ctx.ParentContext as ICustomValidationContext;
				var rootCtx = cctx.GetRootData<CachedData>();
				if (!rootCtx.ExistingCodes.Contains(code)) {
					return false;
				}
				return true;
			})
			.WithMessage("Code does not exist in the database");
	}
}
```
With this approach the validation will be much faster as we will trigger the database only once. Also the parent and child validators can now be registered as singleton, as the new validators don't depend on a database connection anymore. Having singleton validators will additionally speedup the validaton process.
[HERE](https://gist.github.com/maca88/9e4551da22cf53056143bef76148a452) you can find the whole example.
I know that there are a lot of breaking changes, but IMO this feature is a must for complex business applications where we have a lot of validation rules like this.