### PR TITLE
Bug Fix - allow array of primitives in Web Api models

### DIFF
--- a/src/FluentValidation.WebApi/FluentValidationBodyModelValidator.cs
+++ b/src/FluentValidation.WebApi/FluentValidationBodyModelValidator.cs
@@ -82,15 +82,16 @@ namespace FluentValidation.WebApi
 
 		internal static bool IsSimpleType(Type type)
 		{
-			return type.IsPrimitive ||
-				   type.Equals(typeof(string)) ||
+            return type.IsPrimitive ||
+                   (type.IsArray && type.GetElementType().IsPrimitive) ||
+                   type.Equals(typeof(string)) ||
 				   type.Equals(typeof(DateTime)) ||
 				   type.Equals(typeof(Decimal)) ||
 				   type.Equals(typeof(Guid)) ||
 				   type.Equals(typeof(DateTimeOffset)) ||
 				   type.Equals(typeof(TimeSpan));
-		}
-
+        }
+		
 		private bool ValidateNodeAndChildren(ModelMetadata metadata, ValidationContext validationContext, object container) {
 			object model = metadata.Model;
 			bool isValid = true;


### PR DESCRIPTION
I've hit a bug in the Web Api implementation of FluentValidation. When I submit a model with a byte array in it FV tries to load a custom validator for each element of the array (in this case a byte).

The exception being thrown was:

"Additional information: No registration for type IValidator<Byte> could be found. Note that there exists a registration for a different type FluentValidation.IValidator<T> while the requested type is FluentValidation.IValidator<System.Byte>"  

The model being submitted is:
```
    public class CreateDocumentCommand
    {
        public string FileName { get; set; }
        public byte[] Content { get; set; }
        public string Description { get; set; }
    }
```

The implementation is using the factory method (with Simple Injector). 

   ```
 public class ApplicationValidatorFactory : IValidatorFactory
    {
        private readonly Container container;
        public ApplicationValidatorFactory(Container container)
        {
            this.container = container;
        }

        /// <summary>Gets the validator for the specified type.</summary>
        public IValidator<T> GetValidator<T>()
        {
            return container.GetInstance<IValidator<T>>();
        }

        /// <summary>Gets the validator for the specified type.</summary>
        public IValidator GetValidator(Type type)
        {
            var validator = typeof(IValidator<>).MakeGenericType(type);
            var foo = (IValidator)container.GetInstance(validator);   
            return foo;
        }
    }


           FluentValidationModelValidatorProvider.Configure(config, x =>
            {
                x.ValidatorFactory = new ApplicationValidatorFactory(container); 
            });
```
 
The fix below extetends the IsSimpleType method to include arrays of primativetypes and resolves the issue.


Kind Regards

Steve
 