### PR TITLE
IBAN account number validator

### DIFF
--- a/src/FluentValidation.NetStandard/FluentValidation.NetStandard.csproj
+++ b/src/FluentValidation.NetStandard/FluentValidation.NetStandard.csproj
@@ -242,6 +242,9 @@
     <Compile Include="..\FluentValidation\Validators\ExclusiveBetweenValidator.cs">
       <Link>ExclusiveBetweenValidator.cs</Link>
     </Compile>
+    <Compile Include="..\FluentValidation\Validators\IbanValidator.cs">
+      <Link>IbanValidator.cs</Link>
+    </Compile>
     <Compile Include="..\FluentValidation\Validators\InclusiveBetweenValidator.cs">
       <Link>InclusiveBetweenValidator.cs</Link>
     </Compile>

--- a/src/FluentValidation.Portable/FluentValidation.Portable45.csproj
+++ b/src/FluentValidation.Portable/FluentValidation.Portable45.csproj
@@ -240,6 +240,9 @@
     <Compile Include="..\FluentValidation\Validators\ExclusiveBetweenValidator.cs">
       <Link>ExclusiveBetweenValidator.cs</Link>
     </Compile>
+    <Compile Include="..\FluentValidation\Validators\IbanValidator.cs">
+      <Link>IbanValidator.cs</Link>
+    </Compile>
     <Compile Include="..\FluentValidation\Validators\InclusiveBetweenValidator.cs">
       <Link>InclusiveBetweenValidator.cs</Link>
     </Compile>

--- a/src/FluentValidation.Portable40/FluentValidation.Portable40.csproj
+++ b/src/FluentValidation.Portable40/FluentValidation.Portable40.csproj
@@ -238,6 +238,9 @@
     <Compile Include="..\FluentValidation\Validators\ExclusiveBetweenValidator.cs">
       <Link>ExclusiveBetweenValidator.cs</Link>
     </Compile>
+    <Compile Include="..\FluentValidation\Validators\IbanValidator.cs">
+      <Link>IbanValidator.cs</Link>
+    </Compile>
     <Compile Include="..\FluentValidation\Validators\InclusiveBetweenValidator.cs">
       <Link>InclusiveBetweenValidator.cs</Link>
     </Compile>

--- a/src/FluentValidation.Portable46/FluentValidation.Portable46.csproj
+++ b/src/FluentValidation.Portable46/FluentValidation.Portable46.csproj
@@ -243,6 +243,9 @@
     <Compile Include="..\FluentValidation\Validators\ExclusiveBetweenValidator.cs">
       <Link>ExclusiveBetweenValidator.cs</Link>
     </Compile>
+    <Compile Include="..\FluentValidation\Validators\IbanValidator.cs">
+      <Link>IbanValidator.cs</Link>
+    </Compile>
     <Compile Include="..\FluentValidation\Validators\InclusiveBetweenValidator.cs">
       <Link>InclusiveBetweenValidator.cs</Link>
     </Compile>

--- a/src/FluentValidation.Tests.Mvc6.dotnet/FluentValidation.Tests.AspNetCore.dotnet.xproj
+++ b/src/FluentValidation.Tests.Mvc6.dotnet/FluentValidation.Tests.AspNetCore.dotnet.xproj
@@ -14,5 +14,8 @@
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/src/FluentValidation.Tests/FluentValidation.Tests.csproj
+++ b/src/FluentValidation.Tests/FluentValidation.Tests.csproj
@@ -115,6 +115,7 @@
     <Compile Include="ComplexValidationTester.cs" />
     <Compile Include="ConditionTests.cs" />
     <Compile Include="CollectionValidatorWithParentTests.cs" />
+    <Compile Include="IbanValidatorTests.cs" />
     <Compile Include="EnumValidatorTests.cs" />
     <Compile Include="CreditCardValidatorTests.cs" />
     <Compile Include="CultureScope.cs" />

--- a/src/FluentValidation.Tests/IbanValidatorTests.cs
+++ b/src/FluentValidation.Tests/IbanValidatorTests.cs
@@ -1,0 +1,94 @@
+namespace FluentValidation.Tests
+{
+    using System.Globalization;
+    using System.Linq;
+    using System.Threading;
+    using Xunit;
+
+
+    public class IbanValidatorTests
+    {
+        TestValidator validator;
+
+        public IbanValidatorTests()
+        {
+            CultureScope.SetDefaultCulture();
+
+            validator = new TestValidator {
+                v => v.RuleFor(x => x.IbanAccount).IsIBAN()
+            };
+        }
+
+        [Fact]
+        public void IsValidTests()
+        {
+            // Empty values
+            validator.Validate(new Person { IbanAccount = null }).IsValid.ShouldBeTrue(); // Optional values are always valid
+            validator.Validate(new Person { IbanAccount = string.Empty }).IsValid.ShouldBeTrue(); // empty string
+            validator.Validate(new Person { IbanAccount = "\n\r" }).IsValid.ShouldBeTrue(); // new line
+
+            // Valid sample IBAN account numbers
+            validator.Validate(new Person { IbanAccount = "AL90208110080000001039531801" }).IsValid.ShouldBeTrue();
+            validator.Validate(new Person { IbanAccount = "AT611904300234573201" }).IsValid.ShouldBeTrue();
+            validator.Validate(new Person { IbanAccount = "DZ4000400174401001050486" }).IsValid.ShouldBeTrue();
+            validator.Validate(new Person { IbanAccount = "AD1200012030200359100100" }).IsValid.ShouldBeTrue();
+            validator.Validate(new Person { IbanAccount = "AO06000600000100037131174" }).IsValid.ShouldBeTrue();
+            validator.Validate(new Person { IbanAccount = "AT611904300234573201" }).IsValid.ShouldBeTrue();
+            validator.Validate(new Person { IbanAccount = "AZ21NABZ00000000137010001944" }).IsValid.ShouldBeTrue();
+            validator.Validate(new Person { IbanAccount = "BH29BMAG1299123456BH00" }).IsValid.ShouldBeTrue();
+            validator.Validate(new Person { IbanAccount = "BA391290079401028494" }).IsValid.ShouldBeTrue();
+            validator.Validate(new Person { IbanAccount = "BE68539007547034" }).IsValid.ShouldBeTrue();
+            validator.Validate(new Person { IbanAccount = "BJ11B00610100400271101192591" }).IsValid.ShouldBeTrue();
+            validator.Validate(new Person { IbanAccount = "BR9700360305000010009795493P1" }).IsValid.ShouldBeTrue();
+            validator.Validate(new Person { IbanAccount = "BG80BNBG96611020345678" }).IsValid.ShouldBeTrue();
+            validator.Validate(new Person { IbanAccount = "BF1030134020015400945000643" }).IsValid.ShouldBeTrue();
+            validator.Validate(new Person { IbanAccount = "BI43201011067444" }).IsValid.ShouldBeTrue();
+            validator.Validate(new Person { IbanAccount = "CM2110003001000500000605306" }).IsValid.ShouldBeTrue();
+            validator.Validate(new Person { IbanAccount = "CV64000300004547069110176" }).IsValid.ShouldBeTrue();
+            validator.Validate(new Person { IbanAccount = "CR0515202001026284066" }).IsValid.ShouldBeTrue();
+            validator.Validate(new Person { IbanAccount = "CZ6508000000192000145399" }).IsValid.ShouldBeTrue();
+            validator.Validate(new Person { IbanAccount = "DK5000400440116243" }).IsValid.ShouldBeTrue();
+            validator.Validate(new Person { IbanAccount = "NL91ABNA0417164300" }).IsValid.ShouldBeTrue();
+            validator.Validate(new Person { IbanAccount = "NO9386011117947" }).IsValid.ShouldBeTrue();
+            validator.Validate(new Person { IbanAccount = "PL27114020040000300201355387" }).IsValid.ShouldBeTrue();
+            validator.Validate(new Person { IbanAccount = "PT50000201231234567890154" }).IsValid.ShouldBeTrue();
+            validator.Validate(new Person { IbanAccount = "SA0380000000608010167519" }).IsValid.ShouldBeTrue();
+            validator.Validate(new Person { IbanAccount = "CS73260005601001611379" }).IsValid.ShouldBeTrue();
+            validator.Validate(new Person { IbanAccount = "TL380080012345678910157" }).IsValid.ShouldBeTrue();
+            validator.Validate(new Person { IbanAccount = "SI56191000000123438" }).IsValid.ShouldBeTrue();
+            validator.Validate(new Person { IbanAccount = "ES8023100001180000012345" }).IsValid.ShouldBeTrue();
+            validator.Validate(new Person { IbanAccount = "SE3550000000054910000003" }).IsValid.ShouldBeTrue();
+            validator.Validate(new Person { IbanAccount = "CH3900700115201849173" }).IsValid.ShouldBeTrue();
+            validator.Validate(new Person { IbanAccount = "TR330006100519786457841326" }).IsValid.ShouldBeTrue();
+            validator.Validate(new Person { IbanAccount = "IL620108000000099999999" }).IsValid.ShouldBeTrue();
+            validator.Validate(new Person { IbanAccount = "PK36SCBL0000001123456702" }).IsValid.ShouldBeTrue();
+            validator.Validate(new Person { IbanAccount = "BE68844010370034" }).IsValid.ShouldBeTrue();
+            validator.Validate(new Person { IbanAccount = "CZ4201000000195505030267" }).IsValid.ShouldBeTrue();
+            validator.Validate(new Person { IbanAccount = "DK5750510001322617" }).IsValid.ShouldBeTrue();
+            validator.Validate(new Person { IbanAccount = "EE342200221034126658" }).IsValid.ShouldBeTrue();
+            validator.Validate(new Person { IbanAccount = "FI9814283500171141" }).IsValid.ShouldBeTrue();
+            validator.Validate(new Person { IbanAccount = "FR7630066100410001057380116" }).IsValid.ShouldBeTrue();
+            validator.Validate(new Person { IbanAccount = "CH3908704016075473007" }).IsValid.ShouldBeTrue();
+
+            // Corrupted accounts           
+            validator.Validate(new Person { IbanAccount = "CH" }).IsValid.ShouldBeFalse();
+            validator.Validate(new Person { IbanAccount = "CH39" }).IsValid.ShouldBeFalse();
+            validator.Validate(new Person { IbanAccount = " DK5000400440116243" }).IsValid.ShouldBeFalse(); // space
+            validator.Validate(new Person { IbanAccount = "EE382200221020145685!" }).IsValid.ShouldBeFalse(); // not alpha-numereic          
+            validator.Validate(new Person { IbanAccount = "LU$2800194006444750000" }).IsValid.ShouldBeFalse(); // not alpha-numereic
+            validator.Validate(new Person { IbanAccount = "MK07%300000000042425" }).IsValid.ShouldBeFalse(); // not alpha-numereic     
+            validator.Validate(new Person { IbanAccount = "EE3422D555555555555555555555555555555555500221034126658" }).IsValid.ShouldBeFalse(); // too long
+            validator.Validate(new Person { IbanAccount = "FI981428350017114555555556666666666666666666666666666666666666666666666666666666666661" }).IsValid.ShouldBeFalse(); // too long            
+            validator.Validate(new Person { IbanAccount = "CZ4201000000195505030244" }).IsValid.ShouldBeFalse(); // bad check sum
+        }
+
+        [Fact]
+        public void When_validation_fails_the_default_error_should_be_set()
+        {
+            string iban = "foo";
+            var result = validator.Validate(new Person { IbanAccount = iban });
+            result.Errors.Single().ErrorMessage.ShouldEqual("'Iban Account' is not a valid IBAN account number.");
+        }
+
+    }
+}

--- a/src/FluentValidation.Tests/Person.cs
+++ b/src/FluentValidation.Tests/Person.cs
@@ -56,7 +56,9 @@ namespace FluentValidation.Tests
 
 		public string CreditCard { get; set; }
 
-		public int? OtherNullableInt { get; set; }
+        public string IbanAccount { get; set; }
+
+        public int? OtherNullableInt { get; set; }
 
 		public string Regex { get; set; }
 

--- a/src/FluentValidation/DefaultValidatorExtensions.cs
+++ b/src/FluentValidation/DefaultValidatorExtensions.cs
@@ -1002,5 +1002,16 @@ namespace FluentValidation {
 		public static IRuleBuilderOptions<T, TProperty> IsInEnum<T, TProperty>(this IRuleBuilder<T, TProperty> ruleBuilder) {
 			return ruleBuilder.SetValidator(new EnumValidator(typeof(TProperty)));
 		}
+        /// <summary>
+        /// Defines a IBAN validator for the current rule builder that ensures that the specified string is a valid IBAN account number.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <typeparam name="TProperty">The type of the property.</typeparam>
+        /// <param name="ruleBuilder">The rule builder.</param>
+        /// <returns></returns>
+        public static IRuleBuilderOptions<T, TProperty> IsIBAN<T, TProperty>(this IRuleBuilder<T, TProperty> ruleBuilder)
+        {
+            return ruleBuilder.SetValidator(new IbanValidator());
+        }
     }
 }

--- a/src/FluentValidation/FluentValidation.csproj
+++ b/src/FluentValidation/FluentValidation.csproj
@@ -149,6 +149,7 @@
     <Compile Include="Validators\ExclusiveBetweenValidator.cs" />
     <Compile Include="Validators\GreaterThanOrEqualValidator.cs" />
     <Compile Include="Validators\GreaterThanValidator.cs" />
+    <Compile Include="Validators\IbanValidator.cs" />
     <Compile Include="Validators\InclusiveBetweenValidator.cs" />
     <Compile Include="Validators\LessThanOrEqualValidator.cs" />
     <Compile Include="Validators\LessThanValidator.cs" />

--- a/src/FluentValidation/Validators/IbanValidator.cs
+++ b/src/FluentValidation/Validators/IbanValidator.cs
@@ -1,0 +1,76 @@
+﻿#region License
+// Copyright (c) Jeremy Skinner (http://www.jeremyskinner.co.uk)
+// 
+// Licensed under the Apache License, Version 2.0 (the "License"); 
+// you may not use this file except in compliance with the License. 
+// You may obtain a copy of the License at 
+// 
+// http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS, 
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+// 
+// The latest version of this file can be found at http://fluentvalidation.codeplex.com
+#endregion
+
+namespace FluentValidation.Validators
+{
+    using System;
+    using System.Text;
+
+    public class IbanValidator : PropertyValidator
+    {
+        public IbanValidator() : base("'{PropertyName}' is not a valid IBAN account number.") { }
+        protected override bool IsValid(PropertyValidatorContext context)
+        {
+            var value = context.PropertyValue as string;
+
+            return IsValid(value);
+        }
+        private bool IsValid(string bankAccount)
+        {
+            // http://www.codeproject.com/Tips/775696/IBAN-Validator
+            bankAccount = bankAccount?.ToUpper();
+
+            if (string.IsNullOrWhiteSpace(bankAccount))
+                return true;
+
+            if(bankAccount.Length < 5)
+                return false;
+
+            else if (System.Text.RegularExpressions.Regex.IsMatch(bankAccount, "^[a-zA-Z0-9]*$"))
+            {
+                bankAccount = bankAccount.Replace(" ", string.Empty);
+                string bank =
+                bankAccount.Substring(4, bankAccount.Length - 4) + bankAccount.Substring(0, 4);
+                int asciiShift = 55;
+                var sb = new StringBuilder();
+                foreach (char c in bank)
+                {
+                    int v;
+                    if (Char.IsLetter(c)) v = c - asciiShift;
+                    else int.TryParse(c.ToString(), out v);
+                    sb.Append(v);
+                }
+                string checkSumString = sb.ToString();
+                int checksum = int.Parse(checkSumString.Substring(0, 1));
+                for (int i = 1; i < checkSumString.Length; i++)
+                {
+                    int v = 0;
+                    int.TryParse(checkSumString.Substring(i, 1), out v);
+                    checksum *= 10;
+                    checksum += v;
+                    checksum %= 97;
+                }
+                return checksum == 1;
+            }
+            else
+            {
+                return false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Decided to bring International Bank Account Number (IBAN) validator to FluentValidation. I think it would be usefull in many finance related projects especially in Europe.

Credit goes to following CodeProject post :
http://www.codeproject.com/Tips/775696/IBAN-Validator

Summary of changes :
- Added IbanValidator class,
- Added IsIBAN() extension method,
- Unit tests with many valid IBAN accouns.

Will be glad to hear feedback and suggestions.

PS. What is current consensus about built-in validators? Keep it to the minimum or adding common uses cases is welcomed?