### PR TITLE
Fix child validators not being resolved in webapi

### DIFF
--- a/src/FluentValidation.Tests.WebApi/TestController.cs
+++ b/src/FluentValidation.Tests.WebApi/TestController.cs
@@ -22,7 +22,13 @@ namespace FluentValidation.Tests.WebApi {
 	using System.Web.Http.Results;
 
 	public class TestController : ApiController {
-		[HttpPost]
+        [HttpPost]
+        public IHttpActionResult TestModel10(TestModel10 model)
+        {
+            return OutputErrors();
+        }
+
+        [HttpPost]
 		public IHttpActionResult TestModel9(TestModel9 model) {
 			return OutputErrors();
 		}

--- a/src/FluentValidation.Tests.WebApi/TestModels.cs
+++ b/src/FluentValidation.Tests.WebApi/TestModels.cs
@@ -139,4 +139,19 @@ namespace FluentValidation.Tests.WebApi {
             RuleFor(m => m.Name).NotEmpty();
         }
     }
+
+    [Validator(typeof(TestModel10Validator))]
+    public class TestModel10
+    {
+        public string Name { get; set; }
+        public TestModel Child { get; set; }
+    }
+
+    public class TestModel10Validator : AbstractValidator<TestModel10>
+    {
+        public TestModel10Validator()
+        {
+            RuleFor(m => m.Name).NotEmpty();
+        }
+    }
 }

--- a/src/FluentValidation.Tests.WebApi/WebApiIntegrationTests.cs
+++ b/src/FluentValidation.Tests.WebApi/WebApiIntegrationTests.cs
@@ -95,5 +95,13 @@ namespace FluentValidation.Tests.WebApi {
             result.IsValidField("model.Name").ShouldBeFalse();
             result.IsValidField("model.Children[0].Name").ShouldBeFalse();
 	    }
-	}
+
+        [Fact]
+        public void Should_validate_child_properties()
+        {
+            var result = InvokeTest<TestModel10>(@"{Child: {}}", "application/json");
+
+            result.IsValidField("model.Child.Name").ShouldBeFalse();
+        }
+    }
 }

--- a/src/FluentValidation.WebApi/FluentValidationModelValidatorProvider.cs
+++ b/src/FluentValidation.WebApi/FluentValidationModelValidatorProvider.cs
@@ -52,10 +52,6 @@ namespace FluentValidation.WebApi
 
 		public override IEnumerable<ModelValidator> GetValidators(ModelMetadata metadata, IEnumerable<ModelValidatorProvider> validatorProviders)
 		{
-			if (IsValidatingProperty(metadata)) {
-				yield break;
-			}
-
 			IValidator validator = ValidatorFactory.GetValidator(metadata.ModelType);
 			
 			if (validator == null) {
@@ -63,10 +59,6 @@ namespace FluentValidation.WebApi
 			}
 
 			yield return new FluentValidationModelValidator(validatorProviders, validator);
-		}
-
-		protected virtual bool IsValidatingProperty(ModelMetadata metadata) {
-			return metadata.ContainerType != null && !string.IsNullOrEmpty(metadata.PropertyName);
 		}
 	}
 }


### PR DESCRIPTION
This addresses the issue in #433 and #365 where child validators are not resolved.

It seems that if `ValidatorFactory.GetValidator()` returns a validator, you would never want to short circuit validation for that model.