### PR TITLE
Tweak SplitPascalCase to handle UC sequences better

### DIFF
--- a/src/FluentValidation.Tests/ExtensionTester.cs
+++ b/src/FluentValidation.Tests/ExtensionTester.cs
@@ -42,11 +42,16 @@ namespace FluentValidation.Tests {
 		public void Should_split_pascal_cased_member_name() {
 			var cases = new Dictionary<string, string> {
 				            {"DateOfBirth", "Date Of Birth"},
-				            {"DATEOFBIRTH", "D A T E O F B I R T H"},
+				            {"DATEOFBIRTH", "DATEOFBIRTH"},
 				            {"dateOfBirth", "date Of Birth"},
 				            {"dateofbirth", "dateofbirth"},
 							{"Date_Of_Birth", "Date_ Of_ Birth"},
-							{"Name2", "Name2"}
+							{"Name2", "Name2"},
+							{"ProductID", "Product ID"},
+							{"MyTVRemote", "My TV Remote"},
+							{"TVRemote", "TV Remote"},
+							{"XCopy", "X Copy"},
+							{"ThisXCopy", "This X Copy"},
 						};
 
 			foreach (var @case in cases) {

--- a/src/FluentValidation/Internal/Extensions.cs
+++ b/src/FluentValidation/Internal/Extensions.cs
@@ -23,6 +23,8 @@ namespace FluentValidation.Internal {
 	using System.Reflection;
 	using System.Text;
 	using System.Threading.Tasks;
+	using System.Text.RegularExpressions;
+	using System.Linq;
 
 	/// <summary>
 	/// Useful extensions

--- a/src/FluentValidation/Internal/Extensions.cs
+++ b/src/FluentValidation/Internal/Extensions.cs
@@ -102,32 +102,22 @@ namespace FluentValidation.Internal {
 			return toUnwrap;
 		}
 
+		private static Regex _pascalRe = new Regex(@"((^|\p{Lu})\P{Lu}+)|(\p{Lu}+(?=\p{Lu}|$))");
+        
 		/// <summary>
 		/// Splits pascal case, so "FooBar" would become "Foo Bar"
 		/// </summary>
 		public static string SplitPascalCase(this string input)
 		{
-			if (string.IsNullOrEmpty(input))
-			{
+			if (String.IsNullOrEmpty(input))
 				return input;
-			}
 
-			var retVal = new StringBuilder(input.Length + 5);
-
-			foreach (var currentChar in input)
-			{
-				if (char.IsUpper(currentChar))
-				{
-					retVal.Append(' ');
-					retVal.Append(currentChar);					
-				}
-				else
-				{
-					retVal.Append(currentChar);
-				}
-			}
-
-			return retVal.ToString().Trim();
+			
+			var matches = _pascalRe.Matches(input);
+			if (matches.Count == 0)
+				return input;
+			else
+				return String.Join(" ", matches.Cast<Match>().Select(m => m.Value));
 		}
 
 		/// <summary>


### PR DESCRIPTION
I noticed that for property names like `URI`, `SplitPascalCase()` inserts lots of spaces: `U R I`. Changing the function to use a regex lets it be a little smarter about character groupings. Any of the following will be recognized as a group:
1. BOL followed by group of non-UC chars
1. UC char followed by group of non-UC chars 
1. One or more UC chars with lookahead UC char
1. One or more UC chars with lookahead EOL

I added some test cases to the relevant unit test to confirm that this works as expected.