### PR TITLE
Fix how the validator is resolved for classes that look like a collection

### DIFF
--- a/src/FluentValidation.AspNetCore/FluentValidationObjectModelValidator.cs
+++ b/src/FluentValidation.AspNetCore/FluentValidationObjectModelValidator.cs
@@ -49,12 +49,11 @@
 			bool prependPrefix = true;
 
 			if (model != null) {
-				if (metadata.IsCollectionType) {
+				validator = _validatorFactory.GetValidator(metadata.ModelType);
+
+				if (validator == null && metadata.IsCollectionType) {
 					validator = BuildCollectionValidator(prefix, metadata);
 					prependPrefix = false;
-				}
-				else {
-					validator = _validatorFactory.GetValidator(metadata.ModelType);
 				}
 			}
 


### PR DESCRIPTION
In my case, I have a custom subclass of JObject, lets call it *Dog*, and a validator for it *DogValidator*.
But it would identify *Dog* as a collection (because JObject implements ICollection), and thus search for a validator for JToken.