### PR TITLE
ShouldHaveChildValidator: Add any found child validators to the ValidationTestException

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ artifacts/
 TestResults/
 .vs/
 *.lock.json
+*.ncrunch*

--- a/src/FluentValidation.Tests/ValidatorTesterTester.cs
+++ b/src/FluentValidation.Tests/ValidatorTesterTester.cs
@@ -78,7 +78,7 @@ namespace FluentValidation.Tests {
 				validator.ShouldHaveChildValidator(x => x.Address, typeof(AddressValidator))
 			);
 
-			ex.Message.ShouldEqual("Expected property 'Address' to have a child validator of type 'AddressValidator.'");
+			ex.Message.ShouldEqual("Expected property 'Address' to have a child validator of type 'AddressValidator.'. Instead found 'none'");
 		}
 
 
@@ -94,7 +94,18 @@ namespace FluentValidation.Tests {
 				validator.ShouldHaveChildValidator(x => x.Orders, typeof(OrderValidator))
 			);
 
-			ex.Message.ShouldEqual("Expected property 'Orders' to have a child validator of type 'OrderValidator.'");
+			ex.Message.ShouldEqual("Expected property 'Orders' to have a child validator of type 'OrderValidator.'. Instead found 'none'");
+		}
+
+		[Fact]
+		public void ShouldHaveChildValidator_should_throw_when_property_has_a_different_child_validator()
+		{
+			validator.RuleFor(x => x.Address).SetValidator(new AddressValidator());
+			var ex = typeof(ValidationTestException).ShouldBeThrownBy(() =>
+				validator.ShouldHaveChildValidator(x => x.Address, typeof(OrderValidator))
+			);
+
+			ex.Message.ShouldEqual("Expected property 'Address' to have a child validator of type 'OrderValidator.'. Instead found 'AddressValidator'");
 		}
 
 		[Fact]

--- a/src/FluentValidation/TestHelper/ValidatorTestExtensions.cs
+++ b/src/FluentValidation/TestHelper/ValidatorTestExtensions.cs
@@ -63,7 +63,8 @@ namespace FluentValidation.TestHelper {
 			childValidatorTypes = childValidatorTypes.Concat(matchingValidators.OfType<ChildCollectionValidatorAdaptor>().Select(x => x.ChildValidatorType));
 
 			if (childValidatorTypes.All(x => x != childValidatorType)) {
-				throw new ValidationTestException(string.Format("Expected property '{0}' to have a child validator of type '{1}.'", expressionMemberName, childValidatorType.Name));
+				var childValidatorNames = childValidatorTypes.Any() ? string.Join(", ", childValidatorTypes.Select(x => x.Name)) : "none";
+				throw new ValidationTestException(string.Format("Expected property '{0}' to have a child validator of type '{1}.'. Instead found '{2}'", expressionMemberName, childValidatorType.Name, childValidatorNames));
 			}
 		}
 


### PR DESCRIPTION
I have made a minor change to the ShouldHaveChildValidator method. If any child validators are found, then the names of those are output to the ValidationTestException.
