### PR TITLE
Code cleanup in FluentValidation.WebAPI

### DIFF
--- a/src/FluentValidation.WebApi/FluentValidationBodyModelValidator.cs
+++ b/src/FluentValidation.WebApi/FluentValidationBodyModelValidator.cs
@@ -238,12 +238,10 @@ namespace FluentValidation.WebApi
 			if (String.IsNullOrEmpty(prefix)) {
 				return propertyName ?? String.Empty;
 			}
-			else if (String.IsNullOrEmpty(propertyName)) {
-				return prefix ?? String.Empty;
+			if (String.IsNullOrEmpty(propertyName)) {
+				return prefix;
 			}
-			else {
-				return prefix + "." + propertyName;
-			}
+			return prefix + "." + propertyName;
 		}
 
 		private class PropertyScope : IKeyBuilder {


### PR DESCRIPTION
CreatePropertyModelName had unnecessary else if's/else and no need to null coalesce prefix after first check.