### PR TITLE
when setting a conditional validator, register the type of validator …

### DIFF
--- a/src/FluentValidation.Tests/RuleBuilderTests.cs
+++ b/src/FluentValidation.Tests/RuleBuilderTests.cs
@@ -236,6 +236,17 @@ namespace FluentValidation.Tests {
 			results.Single().PropertyName.ShouldEqual("Foo");
 		}
 
+		[Fact]
+		public void Conditional_child_validator_should_register_with_validator_type_not_property() {
+			var builder = new RuleBuilder<Person, Address>(PropertyRule.Create<Person, Address>(x => x.Address));
+			builder.SetValidator(person => new NoopAddressValidator());
+
+			builder.Rule.Validators.OfType<ChildValidatorAdaptor>().Single().ValidatorType.ShouldEqual(typeof(NoopAddressValidator));
+		}
+
+		class NoopAddressValidator : AbstractValidator<Address> {
+		}
+
 		class TestPropertyValidator : PropertyValidator {
 			public TestPropertyValidator() : base(new LanguageStringSource(nameof(NotNullValidator))) {
 				

--- a/src/FluentValidation/Internal/RuleBuilder.cs
+++ b/src/FluentValidation/Internal/RuleBuilder.cs
@@ -68,7 +68,7 @@ namespace FluentValidation.Internal {
 		public IRuleBuilderOptions<T, TProperty> SetValidator<TValidator>(Func<T, TValidator> validatorProvider)
 			where TValidator : IValidator<TProperty> {
 			validatorProvider.Guard("Cannot pass a null validatorProvider to SetValidator");
-			SetValidator(new ChildValidatorAdaptor(t => validatorProvider((T) t), typeof (TProperty)));
+			SetValidator(new ChildValidatorAdaptor(t => validatorProvider((T) t), typeof (TValidator)));
 			return this;
 		}
 


### PR DESCRIPTION
…instead of the property, for the 'validatorType' param.

Hi, when using something like `RuleFor(x => x.Foo).SetValidator(x => new FooValidator(x.Bar))` I noticed that `ShouldHaveChildValidator(x => x.Foo, typeof(FooValidator))` fails telling me `'FooValidator' expected, but found 'TypeOfFoo'` instead, so here is a fix.