### PR TITLE
Update SpanishLanguage.cs

### DIFF
--- a/src/FluentValidation/Resources/Languages/SpanishLanguage.cs
+++ b/src/FluentValidation/Resources/Languages/SpanishLanguage.cs
@@ -38,7 +38,7 @@ namespace FluentValidation.Resources {
 			Translate<AsyncPredicateValidator>("'{PropertyName}' no cumple con la condición especificada.");
 			Translate<RegularExpressionValidator>("'{PropertyName}' no tiene el formato correcto.");
 			Translate<EqualValidator>("'{PropertyName}' debería ser igual a '{ComparisonValue}'.");
-			Translate<ExactLengthValidator>("'{PropertyName}' debe tener una longitude de {MaxLength} caracteres. Actualmente tiene {TotalLength} caracter(es).");
+			Translate<ExactLengthValidator>("'{PropertyName}' debe tener un largo de {MaxLength} caracteres. Actualmente tiene {TotalLength} caracter(es).");
 			Translate<ExclusiveBetweenValidator>("'{PropertyName}' debe estar entre {From} y {To} (exclusivo). Actualmente tiene {Value}.");
 			Translate<InclusiveBetweenValidator>("'{PropertyName}' debe estar entre {From} y {To}. Actualmente tiene {Value}.");
 


### PR DESCRIPTION
The word "longitude" doesn't exist in spanish, the correct is "longitud". You can check the correct word in spanish: http://dle.rae.es/?id=NbKfdrQ

But, the appropiate word for the sentence is "largo", it means "long".