### PR TITLE
Fix ValidationFailure ctor parameter name

### DIFF
--- a/src/FluentValidation/Results/ValidationFailure.cs
+++ b/src/FluentValidation/Results/ValidationFailure.cs
@@ -34,15 +34,15 @@ namespace FluentValidation.Results {
 		/// <summary>
 		/// Creates a new validation failure.
 		/// </summary>
-		public ValidationFailure(string propertyName, string error) : this(propertyName, error, null) {
+		public ValidationFailure(string propertyName, string errorMessage) : this(propertyName, errorMessage, null) {
 		}
 
 		/// <summary>
 		/// Creates a new ValidationFailure.
 		/// </summary>
-		public ValidationFailure(string propertyName, string error, object attemptedValue) {
+		public ValidationFailure(string propertyName, string errorMessage, object attemptedValue) {
 			PropertyName = propertyName;
-			ErrorMessage = error;
+			ErrorMessage = errorMessage;
 			AttemptedValue = attemptedValue;
 		}
 


### PR DESCRIPTION
ValidationFailure ctor param 'error' => 'errorMessage' to match property
name. This allows serialization frameworks like Newtonsoft.Json that
rely on name matching to properly deserialize the type.

I have confirmed that the fix allows ValidationFailure to be automatically deserialized by Newtonsoft.Json 9.x

Fixes #645