### PR TITLE
Should have child validator baseclass

### DIFF
--- a/src/FluentValidation.Tests/ValidatorTesterTester.cs
+++ b/src/FluentValidation.Tests/ValidatorTesterTester.cs
@@ -132,7 +132,7 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public void ShouldHaveChildValidator_should_not_throw_when_property_does_not_have_child_validator() {
+		public void ShouldHaveChildValidator_should_not_throw_when_property_has_collection_validators() {
 			validator.RuleFor(x => x.Orders).SetCollectionValidator(new OrderValidator());
 			validator.ShouldHaveChildValidator(x => x.Orders, typeof(OrderValidator));
 		}

--- a/src/FluentValidation.Tests/ValidatorTesterTester.cs
+++ b/src/FluentValidation.Tests/ValidatorTesterTester.cs
@@ -112,6 +112,13 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
+		public void ShouldHaveChildValidator_should_not_throw_when_property_Does_have_child_validator_and_expecting_a_basetype()
+		{
+			validator.RuleFor(x => x.Address).SetValidator(new AddressValidator());
+			validator.ShouldHaveChildValidator(x => x.Address, typeof(AbstractValidator<Address>));
+		}
+
+		[Fact]
 		public void ShouldHaveChildvalidator_throws_when_collection_property_Does_not_have_child_validator() {
 			var ex = typeof(ValidationTestException).ShouldBeThrownBy(() =>
 				validator.ShouldHaveChildValidator(x => x.Orders, typeof(OrderValidator))

--- a/src/FluentValidation/TestHelper/ValidatorTestExtensions.cs
+++ b/src/FluentValidation/TestHelper/ValidatorTestExtensions.cs
@@ -70,7 +70,7 @@ namespace FluentValidation.TestHelper {
 			var childValidatorTypes = matchingValidators.OfType<ChildValidatorAdaptor>().Select(x => x.ValidatorType);
 			childValidatorTypes = childValidatorTypes.Concat(matchingValidators.OfType<ChildCollectionValidatorAdaptor>().Select(x => x.ChildValidatorType));
 
-			if (childValidatorTypes.All(x => x != childValidatorType)) {
+			if (childValidatorTypes.All(x => !childValidatorType.GetTypeInfo().IsAssignableFrom(x.GetTypeInfo()))) {
 				var childValidatorNames = childValidatorTypes.Any() ? string.Join(", ", childValidatorTypes.Select(x => x.Name)) : "none";
 				throw new ValidationTestException(string.Format("Expected property '{0}' to have a child validator of type '{1}.'. Instead found '{2}'", expressionMemberName, childValidatorType.Name, childValidatorNames));
 			}

--- a/src/FluentValidation/TestHelper/ValidatorTestExtensions.cs
+++ b/src/FluentValidation/TestHelper/ValidatorTestExtensions.cs
@@ -22,6 +22,7 @@ namespace FluentValidation.TestHelper {
 	using System.Collections.Generic;
 	using System.Linq;
 	using System.Linq.Expressions;
+	using System.Reflection;
 	using Internal;
 	using Results;
 	using Validators;


### PR DESCRIPTION
For unit-testing purposes I want to construct my Validator with a mocked ChildValidator using eg. https://github.com/moq/moq4 .

Using ShouldHaveChildValidator gets me the following error:

> Expected property '{propertyName}' to have a child validator of type 'IValidator\`1.'. Instead found 'IValidator`1Proxy'
   at FluentValidation.TestHelper.ValidationTestExtension.ShouldHaveChildValidator

This PR should relax this check a little to allow setting an expectation on a base class but setting the validator to a derived class