### PR TITLE
Added ValidatorInjector, based in Issue #590 - Register open generics…

### DIFF
--- a/src/FluentValidation.Tests/ValidatorInjectorTest.cs
+++ b/src/FluentValidation.Tests/ValidatorInjectorTest.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace FluentValidation.Tests
+{
+    public class ValidatorInjectorTest
+    {
+		
+		[Fact]
+		public void Should_create_new_instance_of_ValidatorInjectorObjectValidator()
+		{
+			var validatorInjector = new ValidatorInjector<ValidatorInjectorObjectValidator>();
+			var model = new ValidatorInjectorObject
+			{
+				Id = 1,
+				Description = "Description"
+			};
+
+			Assert.NotNull(validatorInjector.Validator);
+
+			var validationResult = validatorInjector.Validator.Validate(model);
+			Assert.NotNull(validationResult);
+			Assert.True(validationResult.IsValid);
+		}
+
+	}
+	public interface IValidatorInjectorObject
+	{
+		int Id { get; set; }
+		string Description { get; set; }
+	}
+	public class ValidatorInjectorObject : IValidatorInjectorObject
+	{
+		public int Id { get; set; }
+		public string Description { get; set; }
+	}
+
+	public class ValidatorInjectorObjectValidator : AbstractValidator<IValidatorInjectorObject>
+	{
+		public ValidatorInjectorObjectValidator()
+		{
+			RuleFor(x => x.Id).GreaterThan(0);
+			RuleFor(x => x.Description).NotEmpty();
+		}
+	}
+}

--- a/src/FluentValidation/IValidatorInjector.cs
+++ b/src/FluentValidation/IValidatorInjector.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace FluentValidation
+{
+	public interface IValidatorInjector<TValidator> where TValidator : IValidator, new()
+	{
+		TValidator Validator { get; }
+	}
+}

--- a/src/FluentValidation/ValidatorInjector.cs
+++ b/src/FluentValidation/ValidatorInjector.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace FluentValidation
+{
+	public class ValidatorInjector<TValidator> : IValidatorInjector<TValidator>
+		where TValidator : IValidator, new()
+	{
+		private TValidator validator;
+
+		public TValidator Validator => validator;
+
+		public ValidatorInjector()
+		{
+			validator = new TValidator();
+		}
+	}
+}


### PR DESCRIPTION
@JeremySkinner as mentioned in Issue #590 , in this PR I don't register ValidatorInjector in IoC, like image below:
![image](https://user-images.githubusercontent.com/11986361/38866310-e2abc794-4216-11e8-8223-e61014ab7737.png)
As you can see, it need be registered before to use, or users can instantiate by your self. What you think about that?