### PR TITLE
WebAPI - Add ImplicitlyValidateChildProperties configuration

### DIFF
--- a/src/FluentValidation.Tests.WebApi/StartupRootValidationOnly.cs
+++ b/src/FluentValidation.Tests.WebApi/StartupRootValidationOnly.cs
@@ -1,0 +1,15 @@
+﻿namespace FluentValidation.Tests.WebApi {
+	using System.Web.Http;
+	using FluentValidation.WebApi;
+	using Owin;
+
+	public class StartupRootValidationOnly {
+		public void Configuration(IAppBuilder app) {
+			var config = new HttpConfiguration();
+			config.Routes.MapHttpRoute("Default", "api/{controller}/{action}/{id}", new {id = RouteParameter.Optional});
+			config.IncludeErrorDetailPolicy = IncludeErrorDetailPolicy.Always;
+			FluentValidationModelValidatorProvider.Configure(config, provider => provider.ImplicitlyValidateChildProperties = false);
+			app.UseWebApi(config);
+		}
+	}
+}

--- a/src/FluentValidation.Tests.WebApi/TestController.cs
+++ b/src/FluentValidation.Tests.WebApi/TestController.cs
@@ -23,6 +23,12 @@ namespace FluentValidation.Tests.WebApi {
 	using FluentValidation.WebApi;
 
 	public class TestController : ApiController {
+		[HttpPost]
+		public IHttpActionResult TestModel11(TestModel11 model)
+		{
+			return OutputErrors();
+		}
+		
         [HttpPost]
         public IHttpActionResult TestModel10(TestModel10 model)
         {

--- a/src/FluentValidation.Tests.WebApi/TestController.cs
+++ b/src/FluentValidation.Tests.WebApi/TestController.cs
@@ -24,14 +24,12 @@ namespace FluentValidation.Tests.WebApi {
 
 	public class TestController : ApiController {
 		[HttpPost]
-		public IHttpActionResult TestModel11(TestModel11 model)
-		{
+		public IHttpActionResult TestModel11(TestModel11 model) {
 			return OutputErrors();
 		}
 		
         [HttpPost]
-        public IHttpActionResult TestModel10(TestModel10 model)
-        {
+        public IHttpActionResult TestModel10(TestModel10 model) {
             return OutputErrors();
         }
 

--- a/src/FluentValidation.Tests.WebApi/TestModels.cs
+++ b/src/FluentValidation.Tests.WebApi/TestModels.cs
@@ -149,42 +149,34 @@ namespace FluentValidation.Tests.WebApi {
         public TestModel Child { get; set; }
     }
 
-    public class TestModel10Validator : AbstractValidator<TestModel10>
-    {
-        public TestModel10Validator()
-        {
+    public class TestModel10Validator : AbstractValidator<TestModel10> {
+        public TestModel10Validator() {
             RuleFor(m => m.Name).NotEmpty();
         }
     }
 	
 	[Validator(typeof(TestModel11Validator))]
-	public class TestModel11
-	{
+	public class TestModel11 {
 		public string Name { get; set; }
 		public TestModel Child { get; set; }
 	}
 
-	public class TestModel11Validator : AbstractValidator<TestModel11> 
-	{
-		public TestModel11Validator() 
-		{
+	public class TestModel11Validator : AbstractValidator<TestModel11> {
+		public TestModel11Validator() {
 			RuleFor(m => m.Name).NotEmpty().WithMessage("Validation failed");
 		}
 	}
 	
 	[Validator(typeof(PropertiesValidator))]
-	public class PropertiesTestModel
-	{
+	public class PropertiesTestModel {
 		public string Email { get; set; }
 		public string Surname { get; set; }
 		public string Forename { get; set; }
 	}
 
 
-	public class PropertiesValidator : AbstractValidator<PropertiesTestModel>
-	{
-		public PropertiesValidator()
-		{
+	public class PropertiesValidator : AbstractValidator<PropertiesTestModel> {
+		public PropertiesValidator() {
 			RuleFor(x => x.Email).NotEqual("foo");
 			RuleFor(x => x.Surname).NotEqual("foo");
 			RuleFor(x => x.Forename).NotEqual("foo");
@@ -192,17 +184,14 @@ namespace FluentValidation.Tests.WebApi {
 	}
 
 	[Validator(typeof(RulesetTestValidator))]
-	public class RulesetTestModel
-	{
+	public class RulesetTestModel {
 		public string Email { get; set; }
 		public string Surname { get; set; }
 		public string Forename { get; set; }
 	}
 
-	public class RulesetTestValidator : AbstractValidator<RulesetTestModel>
-	{
-		public RulesetTestValidator()
-		{
+	public class RulesetTestValidator : AbstractValidator<RulesetTestModel> {
+		public RulesetTestValidator() {
 			RuleFor(x => x.Email).NotEqual("foo");
 
 			RuleSet("Names", () => {
@@ -213,59 +202,47 @@ namespace FluentValidation.Tests.WebApi {
 	}
 	
 	[Validator(typeof(PropertiesValidator2))]
-	public class PropertiesTestModel2
-	{
+	public class PropertiesTestModel2 {
 		public string Email { get; set; }
 		public string Surname { get; set; }
 		public string Forename { get; set; }
 	}
-	public class PropertiesValidator2 : AbstractValidator<PropertiesTestModel2>, IValidatorInterceptor
-	{
-		public PropertiesValidator2()
-		{
+	public class PropertiesValidator2 : AbstractValidator<PropertiesTestModel2>, IValidatorInterceptor {
+		public PropertiesValidator2() {
 			RuleFor(x => x.Email).NotEqual("foo");
 			RuleFor(x => x.Surname).NotEqual("foo");
 			RuleFor(x => x.Forename).NotEqual("foo");
 		}
 
-		public ValidationContext BeforeMvcValidation(HttpActionContext controllerContext, ValidationContext validationContext)
-		{
+		public ValidationContext BeforeMvcValidation(HttpActionContext controllerContext, ValidationContext validationContext) {
 			return validationContext;
 		}
 
-		public ValidationResult AfterMvcValidation(HttpActionContext controllerContext, ValidationContext validationContext, ValidationResult result)
-		{
+		public ValidationResult AfterMvcValidation(HttpActionContext controllerContext, ValidationContext validationContext, ValidationResult result) {
 			return new ValidationResult(); //empty errors
 		}
 	}
 
-	public class SimplePropertyInterceptor : IValidatorInterceptor
-	{
+	public class SimplePropertyInterceptor : IValidatorInterceptor {
 		readonly string[] properties = new[] { "Surname", "Forename" };
 
-		public ValidationContext BeforeMvcValidation(HttpActionContext cc, ValidationContext context)
-		{
+		public ValidationContext BeforeMvcValidation(HttpActionContext cc, ValidationContext context) {
 			var newContext = context.Clone(selector: new FluentValidation.Internal.MemberNameValidatorSelector(properties));
 			return newContext;
 		}
 
-		public ValidationResult AfterMvcValidation(HttpActionContext cc, ValidationContext context, ValidationResult result)
-		{
+		public ValidationResult AfterMvcValidation(HttpActionContext cc, ValidationContext context, ValidationResult result) {
 			return result;
 		}
 	}
 
-	public class ClearErrorsInterceptor : IValidatorInterceptor
-	{
-		public ValidationContext BeforeMvcValidation(HttpActionContext cc, ValidationContext context)
-		{
+	public class ClearErrorsInterceptor : IValidatorInterceptor {
+		public ValidationContext BeforeMvcValidation(HttpActionContext cc, ValidationContext context) {
 			return null;
 		}
 
-		public ValidationResult AfterMvcValidation(HttpActionContext cc, ValidationContext context, ValidationResult result)
-		{
+		public ValidationResult AfterMvcValidation(HttpActionContext cc, ValidationContext context, ValidationResult result) {
 			return new ValidationResult();
 		}
 	}
-
 }

--- a/src/FluentValidation.Tests.WebApi/TestModels.cs
+++ b/src/FluentValidation.Tests.WebApi/TestModels.cs
@@ -157,6 +157,20 @@ namespace FluentValidation.Tests.WebApi {
         }
     }
 	
+	[Validator(typeof(TestModel11Validator))]
+	public class TestModel11
+	{
+		public string Name { get; set; }
+		public TestModel Child { get; set; }
+	}
+
+	public class TestModel11Validator : AbstractValidator<TestModel11> 
+	{
+		public TestModel11Validator() 
+		{
+			RuleFor(m => m.Name).NotEmpty().WithMessage("Validation failed");
+		}
+	}
 	
 	[Validator(typeof(PropertiesValidator))]
 	public class PropertiesTestModel

--- a/src/FluentValidation.WebApi/FluentValidationModelValidatorProvider.cs
+++ b/src/FluentValidation.WebApi/FluentValidationModelValidatorProvider.cs
@@ -33,7 +33,7 @@ namespace FluentValidation.WebApi
 
 	public class FluentValidationModelValidatorProvider : ModelValidatorProvider {
 		public IValidatorFactory ValidatorFactory { get; set; }
-
+		public bool ImplicitlyValidateChildProperties { get; set; }
 
 		/// <summary>
 		/// Enabling this maintains compatibility with FluentValidation 6.4, where discovery of validators was limited to top level models. 
@@ -41,6 +41,7 @@ namespace FluentValidation.WebApi
 		public bool DisableDiscoveryOfPropertyValidators { get; set; } = false;
 
 		public FluentValidationModelValidatorProvider(IValidatorFactory validatorFactory = null) {
+			ImplicitlyValidateChildProperties = true;
 			ValidatorFactory = validatorFactory ?? new AttributedValidatorFactory();
 		}
 
@@ -52,7 +53,7 @@ namespace FluentValidation.WebApi
 
 			var provider = new FluentValidationModelValidatorProvider();
 			configurationExpression(provider);
-		    configuration.Services.Replace(typeof(IBodyModelValidator), new FluentValidationBodyModelValidator());
+		    configuration.Services.Replace(typeof(IBodyModelValidator), new FluentValidationBodyModelValidator(provider.ImplicitlyValidateChildProperties));
 			configuration.Services.Add(typeof(ModelValidatorProvider), provider);
 		}
 


### PR DESCRIPTION
I need to validate only the root properties of my templates in my web API.

Currently, the default behavior validates all child properties.

So, I've added a configuration property in the provider that uses the current default behavior.