### PR TITLE
ToString method is implemented for ValidationResult class

### DIFF
--- a/src/FluentValidation.Tests/ValidationResultTests.cs
+++ b/src/FluentValidation.Tests/ValidationResultTests.cs
@@ -17,6 +17,7 @@
 #endregion
 
 namespace FluentValidation.Tests {
+	using System;
 	using Newtonsoft.Json;
 	using Xunit;
 	using Results;
@@ -59,6 +60,49 @@ namespace FluentValidation.Tests {
 			var deserialized = JsonConvert.DeserializeObject<ValidationFailure>(serialized);
 			deserialized.PropertyName.ShouldEqual("Property");
 			deserialized.ErrorMessage.ShouldEqual("Error");
+		}
+
+		[Fact]
+		public void ToString_return_empty_string_when_there_is_no_error() {
+			ValidationResult result = new ValidationResult();
+			string actualResult = result.ToString();
+
+			Assert.Empty(actualResult);
+		}
+
+		[Fact]
+		public void ToString_return_error_messages_with_newline_as_separator() {
+			const string errorMessage1 = "expected error message 1";
+			const string errorMessage2 = "expected error message 2";
+
+			string expectedResult = errorMessage1 + Environment.NewLine + errorMessage2;
+
+			ValidationResult result = new ValidationResult(new[] {
+				new ValidationFailure("property1", errorMessage1),
+				new ValidationFailure("property2", errorMessage2)
+			});
+
+			string actualResult = result.ToString();
+
+			Assert.Equal(expectedResult, actualResult);
+		}
+
+		[Fact]
+		public void ToString_return_error_messages_with_given_separator()
+		{
+			const string errorMessage1 = "expected error message 1";
+			const string errorMessage2 = "expected error message 2";
+			const string separator = "~";
+			const string expectedResult = errorMessage1 + separator + errorMessage2;
+
+			ValidationResult result = new ValidationResult(new[] {
+				new ValidationFailure("property1", errorMessage1),
+				new ValidationFailure("property2", errorMessage2)
+			});
+
+			string actualResult = result.ToString(separator);
+
+			Assert.Equal(expectedResult, actualResult);
 		}
 	}
 }

--- a/src/FluentValidation/Results/ValidationResult.cs
+++ b/src/FluentValidation/Results/ValidationResult.cs
@@ -57,5 +57,13 @@ namespace FluentValidation.Results {
 		public ValidationResult(IEnumerable<ValidationFailure> failures) {
 			errors = failures.Where(failure => failure != null).ToList();
 		}
+
+		public override string ToString() {
+			return ToString(Environment.NewLine);
+		}
+
+		public string ToString(string separator) {
+			return	string.Join(separator,errors.Select(failure => failure.ErrorMessage));
+		}
 	}
 }


### PR DESCRIPTION
When the `ToString` method is called for an instance belonging to the` ValidationResult` class, error messages will be assembled using the `NewLine` separator.

If user want to give separator value, `string ToString (string separator)` method can be used.