### PR TITLE
Tests does not pass when computer culture is not English.

### DIFF
--- a/src/FluentValidation.Tests.AspNetCore/Startup.cs
+++ b/src/FluentValidation.Tests.AspNetCore/Startup.cs
@@ -7,6 +7,8 @@ namespace FluentValidation.Tests.AspNetCore {
 	using FluentValidation.AspNetCore;
 	using FluentValidation.Attributes;
 	using Microsoft.AspNetCore.Mvc.ModelBinding;
+	using System.Globalization;
+	using Microsoft.AspNetCore.Localization;
 
 	public class Startup
     {
@@ -33,8 +35,14 @@ namespace FluentValidation.Tests.AspNetCore {
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
         {
-            app.UseMvc(routes =>
-            {
+            CultureInfo cultureInfo = new CultureInfo("en-US");
+            app.UseRequestLocalization(options => {
+                options.DefaultRequestCulture = new RequestCulture(cultureInfo);
+                options.SupportedCultures = new []{ cultureInfo };
+                options.SupportedUICultures = new []{ cultureInfo };
+            });
+
+            app.UseMvc(routes => {
                 routes.MapRoute(
                     name: "default",
                     template: "{controller=Home}/{action=Index}/{id?}");

--- a/src/FluentValidation.Tests.AspNetCore/StartupWithContainer.cs
+++ b/src/FluentValidation.Tests.AspNetCore/StartupWithContainer.cs
@@ -7,6 +7,8 @@ namespace FluentValidation.Tests.AspNetCore {
 	using Microsoft.Extensions.Logging;
 	using FluentValidation.AspNetCore;
 	using Microsoft.AspNetCore.Http;
+	using System.Globalization;
+	using Microsoft.AspNetCore.Localization;
 
 	public class StartupWithContainer
     {
@@ -34,6 +36,13 @@ namespace FluentValidation.Tests.AspNetCore {
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
         {
+            CultureInfo cultureInfo = new CultureInfo("en-US");
+            app.UseRequestLocalization(options => {
+                options.DefaultRequestCulture = new RequestCulture(cultureInfo);
+                options.SupportedCultures = new []{ cultureInfo };
+                options.SupportedUICultures = new []{ cultureInfo };
+            });
+
             app.UseMvc(routes =>
             {
                 routes.MapRoute(
@@ -63,6 +72,13 @@ namespace FluentValidation.Tests.AspNetCore {
 
 		// This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
 		public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory) {
+			CultureInfo cultureInfo = new CultureInfo("en-US");
+			app.UseRequestLocalization(options => {
+				options.DefaultRequestCulture = new RequestCulture(cultureInfo);
+				options.SupportedCultures = new []{ cultureInfo };
+				options.SupportedUICultures = new []{ cultureInfo };
+			});
+
 			app.UseMvc(routes => {
 				routes.MapRoute(
 					name: "default",

--- a/src/FluentValidation.Tests.AspNetCore/StartupWithMvcValidationDisabled.cs
+++ b/src/FluentValidation.Tests.AspNetCore/StartupWithMvcValidationDisabled.cs
@@ -6,6 +6,8 @@ namespace FluentValidation.Tests.AspNetCore {
 	using Microsoft.Extensions.Logging;
 	using FluentValidation.AspNetCore;
 	using FluentValidation.Attributes;
+	using System.Globalization;
+	using Microsoft.AspNetCore.Localization;
 
 	public class StartupWithMvcValidationDisabled
     {
@@ -31,6 +33,13 @@ namespace FluentValidation.Tests.AspNetCore {
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
         {
+            CultureInfo cultureInfo = new CultureInfo("en-US");
+            app.UseRequestLocalization(options => {
+                options.DefaultRequestCulture = new RequestCulture(cultureInfo);
+                options.SupportedCultures = new []{ cultureInfo };
+                options.SupportedUICultures = new []{ cultureInfo };
+            });
+
             app.UseMvc(routes =>
             {
                 routes.MapRoute(

--- a/src/FluentValidation.Tests/ComparerTester.cs
+++ b/src/FluentValidation.Tests/ComparerTester.cs
@@ -5,6 +5,10 @@
 
 	
 	public class ComparerTester {
+		public ComparerTester() {
+			CultureScope.SetDefaultCulture();
+		}
+
 		[Fact]
 		public void Should_fail_with_different_type_values() {
 			double myDouble = 100.12;

--- a/src/FluentValidation.Tests/CustomMessageFormatTester.cs
+++ b/src/FluentValidation.Tests/CustomMessageFormatTester.cs
@@ -28,6 +28,7 @@ namespace FluentValidation.Tests {
 
 		public CustomMessageFormatTester() {
 			validator = new TestValidator();
+			CultureScope.SetDefaultCulture();
 		}
 
 		[Fact]


### PR DESCRIPTION
Localization leads validation result has different error message which is expected. I set culture info for 

ValidationResult gives a different error message than expected because of lacalization. Therefore, I set culture information for Test/App context.