### PR TITLE
Replacing Microsoft.AspNetCore.Mvc with .Mvc.Core

### DIFF
--- a/src/FluentValidation.AspNetCore/FluentValidation.AspNetCore.csproj
+++ b/src/FluentValidation.AspNetCore/FluentValidation.AspNetCore.csproj
@@ -52,12 +52,14 @@ Full release notes can be found at https://github.com/JeremySkinner/FluentValida
     <Compile Include="..\CommonAssemblyInfo.cs" Link="CommonAssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.0" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\FluentValidation\FluentValidation.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="2.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.1.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Swapping out Microsoft.AspNetCore.Mvc to use Microsoft.AspNetCore.Mvc.Core in order to reduce bundle size;  all AspNetCore tests continue to pass after the swap.