### PR TITLE
Remove netstandard2.0 package references

### DIFF
--- a/src/FluentValidation/FluentValidation.csproj
+++ b/src/FluentValidation/FluentValidation.csproj
@@ -57,7 +57,7 @@ Full release notes can be found at https://github.com/JeremySkinner/FluentValida
   <ItemGroup>
     <Compile Include="..\CommonAssemblyInfo.cs" Link="CommonAssemblyInfo.cs" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'!='netstandard2.0'">
     <PackageReference Include="System.ComponentModel.Primitives" Version="4.3.0" />
     <PackageReference Include="System.Collections.Concurrent" Version="4.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />


### PR DESCRIPTION
Commit 6487ee5 removes the netstandard2.0 package references. Currently it can lead to `NU1605` build errors in consuming projects when another package references a lower package version. To recreate the issue, reference FluentValidator and Json.NET version 9 in a netstandard2.0 project and try to build it.

The other commits are optional.