### PR TITLE
Add extension method for the ScalePrecisionValidator

### DIFF
--- a/src/FluentValidation.Tests/DefaultValidatorExtensionTester.cs
+++ b/src/FluentValidation.Tests/DefaultValidatorExtensionTester.cs
@@ -210,6 +210,19 @@ namespace FluentValidation.Tests {
 			validator.RuleFor(x => x.NullableInt).GreaterThanOrEqualTo(x => x.OtherNullableInt);
 			AssertValidator<GreaterThanOrEqualValidator>();
 		}
+
+		[Fact]
+		public void ScalePrecision_should_create_ScalePrecisionValidator() {
+			validator.RuleFor(x => x.Discount).ScalePrecision(2, 5);
+			AssertValidator<ScalePrecisionValidator>();
+		}
+
+		[Fact]
+		public void ScalePrecision_should_create_ScalePrecisionValidator_with_ignore_trailing_zeros() {
+			validator.RuleFor(x => x.Discount).ScalePrecision(2, 5, true);
+			AssertValidator<ScalePrecisionValidator>();
+		}
+
 		[Fact]
 		public void MustAsync_should_not_throw_InvalidCastException() {
 			var model = new Model

--- a/src/FluentValidation.Tests/ScalePrecisionValidatorTests.cs
+++ b/src/FluentValidation.Tests/ScalePrecisionValidatorTests.cs
@@ -31,7 +31,7 @@ namespace FluentValidation.Tests {
 
 		[Fact]
 		public void Scale_and_precision_should_work() {
-			var validator = new TestValidator(v => v.RuleFor(x => x.Discount).SetValidator(new ScalePrecisionValidator(2, 4)));
+			var validator = new TestValidator(v => v.RuleFor(x => x.Discount).ScalePrecision(2, 4));
 
 			var result = validator.Validate(new Person {Discount = 123.456778m});
 			Assert.False(result.IsValid);
@@ -51,9 +51,7 @@ namespace FluentValidation.Tests {
 			result = validator.Validate(new Person {Discount = 1565.0M}); // fail as it counts zeros
 			result.IsValid.ShouldBeFalse();
 
-			validator = new TestValidator(v =>
-				v.RuleFor(x => x.Discount)
-					.SetValidator(new ScalePrecisionValidator(2, 4) {IgnoreTrailingZeros = true}));
+			validator = new TestValidator(v => v.RuleFor(x => x.Discount).ScalePrecision(2, 4, true));
 
 			result = validator.Validate(new Person {Discount = 1565.0M}); // ignores zeros now
 			result.IsValid.ShouldBeTrue();

--- a/src/FluentValidation/DefaultValidatorExtensions.cs
+++ b/src/FluentValidation/DefaultValidatorExtensions.cs
@@ -1041,9 +1041,13 @@ namespace FluentValidation {
 		/// <param name="ruleBuilder">The rule builder on which the validator should be defined</param>
 		/// <param name="scale">Allowed scale of the value</param>
 		/// <param name="precision">Allowed precision of the value</param>
+		/// <param name="ignoreTrailingZeros">Whether the validator will ignore trailing zeros.</param>
 		/// <returns></returns>
-		public static IRuleBuilderOptions<T, TProperty> ScalePrecision<T, TProperty>(this IRuleBuilder<T, TProperty> ruleBuilder, int scale, int precision) {
-			return ruleBuilder.SetValidator(new ScalePrecisionValidator(scale, precision));
+		public static IRuleBuilderOptions<T, TProperty> ScalePrecision<T, TProperty>(this IRuleBuilder<T, TProperty> ruleBuilder, int scale, int precision, bool ignoreTrailingZeros = false) {
+			var validator = new ScalePrecisionValidator(scale, precision) {
+				IgnoreTrailingZeros = ignoreTrailingZeros
+			};
+			return ruleBuilder.SetValidator(validator);
 		}
 
 		/// <summary>

--- a/src/FluentValidation/DefaultValidatorExtensions.cs
+++ b/src/FluentValidation/DefaultValidatorExtensions.cs
@@ -1033,6 +1033,18 @@ namespace FluentValidation {
 			return ruleBuilder.SetValidator(new EnumValidator(typeof(TProperty)));
 		}
 
+		/// <summary>
+		/// Defines a scale precision validator on the current rule builder that ensures that the specific value has a certain scale and precision
+		/// </summary>
+		/// <typeparam name="T">Type of object being validated</typeparam>
+		/// <typeparam name="TProperty">Type of property being validated</typeparam>
+		/// <param name="ruleBuilder">The rule builder on which the validator should be defined</param>
+		/// <param name="scale">Allowed scale of the value</param>
+		/// <param name="precision">Allowed precision of the value</param>
+		/// <returns></returns>
+		public static IRuleBuilderOptions<T, TProperty> ScalePrecision<T, TProperty>(this IRuleBuilder<T, TProperty> ruleBuilder, int scale, int precision) {
+			return ruleBuilder.SetValidator(new ScalePrecisionValidator(scale, precision));
+		}
 
 		/// <summary>
 		/// Defines a custom validation rule

--- a/src/FluentValidation/DefaultValidatorExtensions.cs
+++ b/src/FluentValidation/DefaultValidatorExtensions.cs
@@ -1044,10 +1044,7 @@ namespace FluentValidation {
 		/// <param name="ignoreTrailingZeros">Whether the validator will ignore trailing zeros.</param>
 		/// <returns></returns>
 		public static IRuleBuilderOptions<T, TProperty> ScalePrecision<T, TProperty>(this IRuleBuilder<T, TProperty> ruleBuilder, int scale, int precision, bool ignoreTrailingZeros = false) {
-			var validator = new ScalePrecisionValidator(scale, precision) {
-				IgnoreTrailingZeros = ignoreTrailingZeros
-			};
-			return ruleBuilder.SetValidator(validator);
+			return ruleBuilder.SetValidator(new ScalePrecisionValidator(scale, precision) { IgnoreTrailingZeros = ignoreTrailingZeros });
 		}
 
 		/// <summary>


### PR DESCRIPTION
Added an extension method to add a `ScalePrecisionValidator` to an `IRuleBuilder`.

eg:
```csharp
validator.RuleFor(x => x.DecimalValue).ScalePrecision(2, 7);
```
#1000 