### PR TITLE
Add CountValidator for ICollection properties

### DIFF
--- a/docs/_doc/validators/built-in-validators.md
+++ b/docs/_doc/validators/built-in-validators.md
@@ -21,6 +21,7 @@ sections:
   - ExclusiveBetween Validator
   - InclusiveBetween Validator
   - ScalePrecision Validator
+  - Collection Count Validator
 ---
 
 
@@ -355,3 +356,19 @@ String format args:
 * {actualScale} = The actual scale of the property value
 
 Note that this method contains an additional optional parameter `ignoreTrailingZeros`. When set to true, trailing zeros after the decimal point will not count towards the expected number of decimal places. By default, this is set to `false`.
+
+#### Collection Count Validator
+Checks whether the number of items in a collection is within the specified range.
+
+```csharp
+RuleFor(x => x.Orders).Count(1, 10);
+```
+
+Example error: 'Orders' must have between 1 and 10 elements, but actually contains 12 elements.");
+
+String format args:
+* {PropertyName} = The name of the property being validated
+* {PropertyValue} = The current value of the property
+* {Min} = The minimum number of items allowed in the collection
+* {Max} = The maximum number of items allowed in the collection
+* {Total} = The current total number of items in the collection 

--- a/src/FluentValidation.Tests/CountValidatorTests.cs
+++ b/src/FluentValidation.Tests/CountValidatorTests.cs
@@ -1,0 +1,99 @@
+﻿#region License
+// Copyright (c) Jeremy Skinner (http://www.jeremyskinner.co.uk)
+// 
+// Licensed under the Apache License, Version 2.0 (the "License"); 
+// you may not use this file except in compliance with the License. 
+// You may obtain a copy of the License at 
+// 
+// http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS, 
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+// 
+// The latest version of this file can be found at https://github.com/jeremyskinner/FluentValidation
+#endregion
+
+namespace FluentValidation.Tests
+{
+	using System;
+	using System.Linq;
+	using Validators;
+	using Xunit;
+
+	public class CountValidatorTests
+	{
+		[Fact]
+		public void When_the_min_is_negative_then_the_validator_should_throw() {
+			typeof(ArgumentOutOfRangeException).ShouldBeThrownBy(() =>
+				new TestValidator(v => v.RuleFor(x => x.Children).Count(-1, 0)));
+		}
+
+		[Fact]
+		public void When_the_max_is_smaller_than_the_min_then_the_validator_should_throw() {
+			typeof(ArgumentOutOfRangeException).ShouldBeThrownBy(() =>
+				new TestValidator(v => v.RuleFor(x => x.Children).Count(2, 1)));
+		}
+
+		[Fact]
+		public void When_the_count_is_between_the_range_then_the_validator_should_pass() {
+			var validator = new TestValidator(v => v.RuleFor(x => x.Children).Count(1, 3));
+			var result = validator.Validate(PersonWithChildren(2));
+			result.IsValid.ShouldBeTrue();
+		}
+
+		[Fact]
+		public void When_the_count_is_exactly_the_size_of_the_lower_bound_then_the_validator_should_pass() {
+			var validator = new TestValidator(v => v.RuleFor(x => x.Children).Count(1, 3));
+			var result = validator.Validate(PersonWithChildren(1));
+			result.IsValid.ShouldBeTrue();
+		}
+
+		[Fact]
+		public void When_the_count_is_exactly_the_size_of_the_upper_bound_then_the_validator_should_pass() {
+			var validator = new TestValidator(v => v.RuleFor(x => x.Children).Count(1, 3));
+			var result = validator.Validate(PersonWithChildren(3));
+			result.IsValid.ShouldBeTrue();
+		}
+
+		[Fact]
+		public void When_the_count_is_smaller_than_the_range_then_the_validator_should_fail() {
+			var validator = new TestValidator(v => v.RuleFor(x => x.Children).Count(1, 3));
+			var result = validator.Validate(PersonWithChildren(0));
+			result.IsValid.ShouldBeFalse();
+		}
+
+		[Fact]
+		public void When_the_count_is_larger_than_the_range_then_the_validator_should_fail() {
+			var validator = new TestValidator(v => v.RuleFor(x => x.Children).Count(1, 3));
+			var result = validator.Validate(PersonWithChildren(4));
+			result.IsValid.ShouldBeFalse();
+		}
+
+		[Fact]
+		public void When_the_validator_fails_the_error_message_should_be_set() {
+			var validator = new TestValidator(v => v.RuleFor(x => x.Children).Count(1, 3));
+			var result = validator.Validate(PersonWithChildren(4));
+			result.Errors.Single().ErrorMessage.ShouldEqual("'Children' must have between 1 and 3 elements. You provided 4 elements.");
+		}
+
+		[Fact]
+		public void Min_and_max_properties_should_be_set() {
+			var validator = new CountValidator(1, 3);
+			validator.Min.ShouldEqual(1);
+			validator.Max.ShouldEqual(3);
+		}
+
+		[Fact]
+		public void When_input_is_null_then_the_validator_should_pass() {
+			var validator = new TestValidator(v => v.RuleFor(x => x.Children).Count(1, 3));
+			var result = validator.Validate(new Person {Children = null});
+			result.IsValid.ShouldBeTrue();
+		}
+
+		private static Person PersonWithChildren(int num) =>
+			new Person{Children = Enumerable.Repeat(new Person(), num).ToList()}; 
+	}
+}

--- a/src/FluentValidation.Tests/CountValidatorTests.cs
+++ b/src/FluentValidation.Tests/CountValidatorTests.cs
@@ -1,4 +1,5 @@
 ﻿#region License
+
 // Copyright (c) Jeremy Skinner (http://www.jeremyskinner.co.uk)
 // 
 // Licensed under the Apache License, Version 2.0 (the "License"); 
@@ -14,17 +15,20 @@
 // limitations under the License.
 // 
 // The latest version of this file can be found at https://github.com/jeremyskinner/FluentValidation
+
 #endregion
 
-namespace FluentValidation.Tests
-{
+namespace FluentValidation.Tests {
 	using System;
 	using System.Linq;
 	using Validators;
 	using Xunit;
 
-	public class CountValidatorTests
-	{
+	public class CountValidatorTests {
+		public CountValidatorTests() {
+			CultureScope.SetDefaultCulture();
+		}
+
 		[Fact]
 		public void When_the_min_is_negative_then_the_validator_should_throw() {
 			typeof(ArgumentOutOfRangeException).ShouldBeThrownBy(() =>
@@ -76,7 +80,7 @@ namespace FluentValidation.Tests
 		public void When_the_validator_fails_the_error_message_should_be_set() {
 			var validator = new TestValidator(v => v.RuleFor(x => x.Children).Count(1, 3));
 			var result = validator.Validate(PersonWithChildren(4));
-			result.Errors.Single().ErrorMessage.ShouldEqual("'Children' must have between 1 and 3 elements. You provided 4 elements.");
+			result.Errors.Single().ErrorMessage.ShouldEqual("'Children' must have between 1 and 3 elements, but actually contains 4 elements.");
 		}
 
 		[Fact]
@@ -94,6 +98,6 @@ namespace FluentValidation.Tests
 		}
 
 		private static Person PersonWithChildren(int num) =>
-			new Person{Children = Enumerable.Repeat(new Person(), num).ToList()}; 
+			new Person {Children = Enumerable.Repeat(new Person(), num).ToList()};
 	}
 }

--- a/src/FluentValidation/DefaultValidatorExtensions.cs
+++ b/src/FluentValidation/DefaultValidatorExtensions.cs
@@ -19,7 +19,6 @@
 namespace FluentValidation {
 	using System;
 	using System.Collections;
-	using System.Collections.Generic;
 	using System.Linq;
 	using System.Linq.Expressions;
 	using System.Text.RegularExpressions;
@@ -1045,6 +1044,19 @@ namespace FluentValidation {
 		/// <returns></returns>
 		public static IRuleBuilderOptions<T, TProperty> ScalePrecision<T, TProperty>(this IRuleBuilder<T, TProperty> ruleBuilder, int scale, int precision, bool ignoreTrailingZeros = false) {
 			return ruleBuilder.SetValidator(new ScalePrecisionValidator(scale, precision) { IgnoreTrailingZeros = ignoreTrailingZeros });
+		}
+
+		/// <summary>
+		/// Defines a count validator on the current rule builder, but only for collection properties.
+		/// Validation will fail if the number of elements is outside of the specified range. The range is inclusive.
+		/// </summary>
+		/// <typeparam name="T">Type of object being validated</typeparam>
+		/// <param name="ruleBuilder">The rule builder on which the validator should be defined</param>
+		/// <param name="min"></param>
+		/// <param name="max"></param>
+		/// <returns></returns>
+		public static IRuleBuilderOptions<T, ICollection> Count<T>(this IRuleBuilder<T, ICollection> ruleBuilder, int min, int max) {
+			return ruleBuilder.SetValidator(new CountValidator(min, max));
 		}
 
 		/// <summary>

--- a/src/FluentValidation/DefaultValidatorExtensions.cs
+++ b/src/FluentValidation/DefaultValidatorExtensions.cs
@@ -1051,11 +1051,12 @@ namespace FluentValidation {
 		/// Validation will fail if the number of elements is outside of the specified range. The range is inclusive.
 		/// </summary>
 		/// <typeparam name="T">Type of object being validated</typeparam>
+		/// <typeparam name="TProperty">Type of property being validated</typeparam>
 		/// <param name="ruleBuilder">The rule builder on which the validator should be defined</param>
 		/// <param name="min"></param>
 		/// <param name="max"></param>
 		/// <returns></returns>
-		public static IRuleBuilderOptions<T, ICollection> Count<T>(this IRuleBuilder<T, ICollection> ruleBuilder, int min, int max) {
+		public static IRuleBuilderOptions<T, TProperty> Count<T, TProperty>(this IRuleBuilder<T, TProperty> ruleBuilder, int min, int max) where TProperty : ICollection {
 			return ruleBuilder.SetValidator(new CountValidator(min, max));
 		}
 

--- a/src/FluentValidation/Resources/Languages/EnglishLanguage.cs
+++ b/src/FluentValidation/Resources/Languages/EnglishLanguage.cs
@@ -46,7 +46,7 @@ namespace FluentValidation.Resources {
 			Translate<EmptyValidator>("'{PropertyName}' must be empty.");
 			Translate<NullValidator>("'{PropertyName}' must be empty.");
 			Translate<EnumValidator>("'{PropertyName}' has a range of values which does not include '{PropertyValue}'.");
-			Translate<CountValidator>("'{PropertyName}' must have between {MinCount} and {MaxCount} elements. You provided {Count} elements.");
+			Translate<CountValidator>("'{PropertyName}' must have between {Min} and {Max} elements, but actually contains {Total} elements.");
 		}
 	}
 }

--- a/src/FluentValidation/Resources/Languages/EnglishLanguage.cs
+++ b/src/FluentValidation/Resources/Languages/EnglishLanguage.cs
@@ -46,6 +46,7 @@ namespace FluentValidation.Resources {
 			Translate<EmptyValidator>("'{PropertyName}' must be empty.");
 			Translate<NullValidator>("'{PropertyName}' must be empty.");
 			Translate<EnumValidator>("'{PropertyName}' has a range of values which does not include '{PropertyValue}'.");
+			Translate<CountValidator>("'{PropertyName}' must have between {MinCount} and {MaxCount} elements. You provided {Count} elements.");
 		}
 	}
 }

--- a/src/FluentValidation/Validators/CountValidator.cs
+++ b/src/FluentValidation/Validators/CountValidator.cs
@@ -18,14 +18,12 @@
 
 #endregion
 
-namespace FluentValidation.Validators
-{
+namespace FluentValidation.Validators {
 	using System;
 	using System.Collections;
 	using Resources;
 
-	public class CountValidator : PropertyValidator
-	{
+	public class CountValidator : PropertyValidator {
 		public int Min { get; }
 		public int Max { get; }
 
@@ -43,15 +41,15 @@ namespace FluentValidation.Validators
 			if (!(context.PropertyValue is ICollection collection))
 				return true;
 
-			var count = collection.Count;
+			var total = collection.Count;
 
-			if (count >= Min && count <= Max)
+			if (total >= Min && total <= Max)
 				return true;
-			
+
 			context.MessageFormatter
-				.AppendArgument("MinCount", Min)
-				.AppendArgument("MaxCount", Max)
-				.AppendArgument("Count", count);
+				.AppendArgument("Min", Min)
+				.AppendArgument("Max", Max)
+				.AppendArgument("Total", total);
 			return false;
 		}
 	}

--- a/src/FluentValidation/Validators/CountValidator.cs
+++ b/src/FluentValidation/Validators/CountValidator.cs
@@ -1,0 +1,58 @@
+﻿#region License
+
+// Copyright (c) Jeremy Skinner (http://www.jeremyskinner.co.uk)
+// 
+// Licensed under the Apache License, Version 2.0 (the "License"); 
+// you may not use this file except in compliance with the License. 
+// You may obtain a copy of the License at 
+// 
+// http://www.apache.org/licenses/LICENSE-2.0 
+// 
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS, 
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+// 
+// The latest version of this file can be found at https://github.com/jeremyskinner/FluentValidation
+
+#endregion
+
+namespace FluentValidation.Validators
+{
+	using System;
+	using System.Collections;
+	using Resources;
+
+	public class CountValidator : PropertyValidator
+	{
+		public int Min { get; }
+		public int Max { get; }
+
+		public CountValidator(int min, int max) : base(new LanguageStringSource(nameof(CountValidator))) {
+			if (min < 0)
+				throw new ArgumentOutOfRangeException(nameof(min), "Min should be equal to or greater than zero.");
+			if (max < min)
+				throw new ArgumentOutOfRangeException(nameof(max), "Max should be equal to or greater than min.");
+
+			Min = min;
+			Max = max;
+		}
+
+		protected override bool IsValid(PropertyValidatorContext context) {
+			if (!(context.PropertyValue is ICollection collection))
+				return true;
+
+			var count = collection.Count;
+
+			if (count >= Min && count <= Max)
+				return true;
+			
+			context.MessageFormatter
+				.AppendArgument("MinCount", Min)
+				.AppendArgument("MaxCount", Max)
+				.AppendArgument("Count", count);
+			return false;
+		}
+	}
+}


### PR DESCRIPTION
Add a validator for properties implementing ICollection. The validator
allows specification of a range for the allowed number of elements in
the collection.

Closes #1013.