### PR TITLE
Add a validator test extension for checking failure severity

### DIFF
--- a/src/FluentValidation.Tests/ValidatorTesterTester.cs
+++ b/src/FluentValidation.Tests/ValidatorTesterTester.cs
@@ -311,6 +311,25 @@ namespace FluentValidation.Tests {
 			exceptionCaught.ShouldBeTrue();
 		}
 
+		[Fact]
+		public void Expected_severity_check() {
+			bool exceptionCaught = false;
+
+			try {
+				var validator = new InlineValidator<Person> {
+					v => v.RuleFor(x => x.Surname).NotNull().WithSeverity(Severity.Warning)
+				};
+				validator.ShouldHaveValidationErrorFor(x => x.Surname, null as string).WithSeverity(Severity.Error);
+			}
+			catch (ValidationTestException e) {
+				exceptionCaught = true;
+
+				e.Message.ShouldEqual($"Expected a severity of '{nameof(Severity.Error)}'. Actual severity was '{nameof(Severity.Warning)}'");
+			}
+
+			exceptionCaught.ShouldBeTrue();
+		}
+
 		[Theory]
 		[InlineData(42, null)]
 		[InlineData(42, "")]

--- a/src/FluentValidation/TestHelper/ValidatorTestExtensions.cs
+++ b/src/FluentValidation/TestHelper/ValidatorTestExtensions.cs
@@ -128,7 +128,8 @@ namespace FluentValidation.TestHelper {
 				if (exceptionMessage != null) {
 					message = exceptionMessage.Replace("{Code}", failure.ErrorCode)
 						.Replace("{Message}", failure.ErrorMessage)
-						.Replace("{State}", failure.CustomState?.ToString() ?? "");
+						.Replace("{State}", failure.CustomState?.ToString() ?? "")
+						.Replace("{Severity}", failure.Severity.ToString());
 				}
 
 				throw new ValidationTestException(message);
@@ -147,6 +148,10 @@ namespace FluentValidation.TestHelper {
 
 		public static IEnumerable<ValidationFailure> WithErrorCode(this IEnumerable<ValidationFailure> failures, string expectedErrorCode) {
 			return failures.When(failure => failure.ErrorCode == expectedErrorCode, string.Format("Expected an error code of '{0}'. Actual error code was '{{Code}}'", expectedErrorCode));
+		}
+
+		public static IEnumerable<ValidationFailure> WithSeverity(this IEnumerable<ValidationFailure> failures, Severity expectedSeverity) {
+			return failures.When(failure => failure.Severity == expectedSeverity, string.Format("Expected a severity of '{0}'. Actual severity was '{{Severity}}'", expectedSeverity));
 		}
 	}
 }


### PR DESCRIPTION
Added a test helper extension method for testing/asserting on validation failure Severity, similar to those for custom state, messages, and error codes.

I have an extension method in my own code to do exactly this, tying it in with the expected/actual messaging would be swell.