### PR TITLE
validator test: Added `without` extensions and tests

### DIFF
--- a/src/FluentValidation.Tests/ValidatorTesterTester.cs
+++ b/src/FluentValidation.Tests/ValidatorTesterTester.cs
@@ -294,8 +294,7 @@ namespace FluentValidation.Tests {
 				}
 				validator.TestValidate(new Person { }).Result.Errors.WithoutErrorMessage(withoutErrMsg);
 			}
-			catch (ValidationTestException e)
-			{
+			catch (ValidationTestException e) {
 				exceptionCaught = true;
 
 				e.Message.ShouldEqual($"Unexpected an error message of '{withoutErrMsg}'");
@@ -334,8 +333,7 @@ namespace FluentValidation.Tests {
 				};
 				validator.ShouldHaveValidationErrorFor(x => x.Surname, null as string).WithoutCustomState("bar");
 			}
-			catch (ValidationTestException e)
-			{
+			catch (ValidationTestException e) {
 				exceptionCaught = true;
 
 				e.Message.ShouldEqual("Unexpected custom state of 'bar'");
@@ -374,8 +372,7 @@ namespace FluentValidation.Tests {
 				};
 				validator.ShouldHaveValidationErrorFor(x => x.Surname, null as string).WithoutErrorCode("bar");
 			}
-			catch (ValidationTestException e)
-			{
+			catch (ValidationTestException e) {
 				exceptionCaught = true;
 
 				e.Message.ShouldEqual("Unexpected an error code of 'bar'");
@@ -414,8 +411,7 @@ namespace FluentValidation.Tests {
 				};
 				validator.ShouldHaveValidationErrorFor(x => x.Surname, null as string).WithoutSeverity(Severity.Warning);
 			}
-			catch (ValidationTestException e)
-			{
+			catch (ValidationTestException e) {
 				exceptionCaught = true;
 
 				e.Message.ShouldEqual($"Unexpected a severity of '{nameof(Severity.Warning)}'");

--- a/src/FluentValidation.Tests/ValidatorTesterTester.cs
+++ b/src/FluentValidation.Tests/ValidatorTesterTester.cs
@@ -274,6 +274,28 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
+		public void Unexpected_message_check() {
+			bool exceptionCaught = false;
+
+			try
+			{
+				var validator = new InlineValidator<Person> {
+					v => v.RuleFor(x => x.Surname).NotNull().WithMessage("bar"),
+					v => v.RuleFor(x => x.Surname).NotNull().WithMessage("foo"),
+				};
+				validator.ShouldHaveValidationErrorFor(x => x.Surname, null as string).WithoutErrorMessage("bar");
+			}
+			catch (ValidationTestException e)
+			{
+				exceptionCaught = true;
+
+				e.Message.ShouldEqual("Unexpected an error message of 'bar'");
+			}
+
+			exceptionCaught.ShouldBeTrue();
+		}
+
+		[Fact]
 		public void Expected_state_check() {
 			bool exceptionCaught = false;
 
@@ -287,6 +309,28 @@ namespace FluentValidation.Tests {
 				exceptionCaught = true;
 
 				e.Message.ShouldEqual("Expected custom state of 'foo'. Actual state was 'bar'");
+			}
+
+			exceptionCaught.ShouldBeTrue();
+		}
+
+		[Fact]
+		public void Unexpected_state_check() {
+			bool exceptionCaught = false;
+
+			try
+			{
+				var validator = new InlineValidator<Person> {
+					v => v.RuleFor(x => x.Surname).NotNull().WithState(x => "bar"),
+					v => v.RuleFor(x => x.Surname).NotNull().WithState(x => "foo"),
+				};
+				validator.ShouldHaveValidationErrorFor(x => x.Surname, null as string).WithoutCustomState("bar");
+			}
+			catch (ValidationTestException e)
+			{
+				exceptionCaught = true;
+
+				e.Message.ShouldEqual("Unexpected custom state of 'bar'");
 			}
 
 			exceptionCaught.ShouldBeTrue();
@@ -312,6 +356,28 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
+		public void Unexpected_error_code_check() {
+			bool exceptionCaught = false;
+
+			try
+			{
+				var validator = new InlineValidator<Person> {
+					v => v.RuleFor(x => x.Surname).NotNull().WithErrorCode("bar"),
+					v => v.RuleFor(x => x.Surname).NotNull().WithErrorCode("foo")
+				};
+				validator.ShouldHaveValidationErrorFor(x => x.Surname, null as string).WithoutErrorCode("bar");
+			}
+			catch (ValidationTestException e)
+			{
+				exceptionCaught = true;
+
+				e.Message.ShouldEqual("Unexpected an error code of 'bar'");
+			}
+
+			exceptionCaught.ShouldBeTrue();
+		}
+
+		[Fact]
 		public void Expected_severity_check() {
 			bool exceptionCaught = false;
 
@@ -325,6 +391,28 @@ namespace FluentValidation.Tests {
 				exceptionCaught = true;
 
 				e.Message.ShouldEqual($"Expected a severity of '{nameof(Severity.Error)}'. Actual severity was '{nameof(Severity.Warning)}'");
+			}
+
+			exceptionCaught.ShouldBeTrue();
+		}
+
+		[Fact]
+		public void Unexpected_severity_check() {
+			bool exceptionCaught = false;
+
+			try
+			{
+				var validator = new InlineValidator<Person> {
+					v => v.RuleFor(x => x.Surname).NotNull().WithSeverity(Severity.Warning),
+					v => v.RuleFor(x => x.Surname).NotNull().WithSeverity(Severity.Error),
+				};
+				validator.ShouldHaveValidationErrorFor(x => x.Surname, null as string).WithoutSeverity(Severity.Warning);
+			}
+			catch (ValidationTestException e)
+			{
+				exceptionCaught = true;
+
+				e.Message.ShouldEqual($"Unexpected a severity of '{nameof(Severity.Warning)}'");
 			}
 
 			exceptionCaught.ShouldBeTrue();

--- a/src/FluentValidation.Tests/ValidatorTesterTester.cs
+++ b/src/FluentValidation.Tests/ValidatorTesterTester.cs
@@ -297,7 +297,7 @@ namespace FluentValidation.Tests {
 			catch (ValidationTestException e) {
 				exceptionCaught = true;
 
-				e.Message.ShouldEqual($"Unexpected an error message of '{withoutErrMsg}'");
+				e.Message.ShouldEqual($"Found an unexpected error message of '{withoutErrMsg}'");
 			}
 
 			exceptionCaught.ShouldEqual(errMessages.Contains(withoutErrMsg));
@@ -336,7 +336,7 @@ namespace FluentValidation.Tests {
 			catch (ValidationTestException e) {
 				exceptionCaught = true;
 
-				e.Message.ShouldEqual("Unexpected custom state of 'bar'");
+				e.Message.ShouldEqual("Found an unexpected custom state of 'bar'");
 			}
 
 			exceptionCaught.ShouldBeTrue();
@@ -375,7 +375,7 @@ namespace FluentValidation.Tests {
 			catch (ValidationTestException e) {
 				exceptionCaught = true;
 
-				e.Message.ShouldEqual("Unexpected an error code of 'bar'");
+				e.Message.ShouldEqual("Found an unexpected error code of 'bar'");
 			}
 
 			exceptionCaught.ShouldBeTrue();
@@ -414,7 +414,7 @@ namespace FluentValidation.Tests {
 			catch (ValidationTestException e) {
 				exceptionCaught = true;
 
-				e.Message.ShouldEqual($"Unexpected a severity of '{nameof(Severity.Warning)}'");
+				e.Message.ShouldEqual($"Found an unexpected severity of '{nameof(Severity.Warning)}'");
 			}
 
 			exceptionCaught.ShouldBeTrue();

--- a/src/FluentValidation.Tests/ValidatorTesterTester.cs
+++ b/src/FluentValidation.Tests/ValidatorTesterTester.cs
@@ -287,8 +287,7 @@ namespace FluentValidation.Tests {
 		public void Unexpected_message_check(string withoutErrMsg, string[] errMessages) {
 			bool exceptionCaught = false;
 
-			try
-			{
+			try {
 				var validator = new InlineValidator<Person>();
 				foreach(var msg in errMessages) {
 					validator.Add(v => v.RuleFor(x => x.Surname).NotNull().WithMessage(msg));
@@ -328,8 +327,7 @@ namespace FluentValidation.Tests {
 		public void Unexpected_state_check() {
 			bool exceptionCaught = false;
 
-			try
-			{
+			try {
 				var validator = new InlineValidator<Person> {
 					v => v.RuleFor(x => x.Surname).NotNull().WithState(x => "bar"),
 					v => v.RuleFor(x => x.Surname).NotNull().WithState(x => "foo"),
@@ -369,8 +367,7 @@ namespace FluentValidation.Tests {
 		public void Unexpected_error_code_check() {
 			bool exceptionCaught = false;
 
-			try
-			{
+			try {
 				var validator = new InlineValidator<Person> {
 					v => v.RuleFor(x => x.Surname).NotNull().WithErrorCode("bar"),
 					v => v.RuleFor(x => x.Surname).NotNull().WithErrorCode("foo")
@@ -410,8 +407,7 @@ namespace FluentValidation.Tests {
 		public void Unexpected_severity_check() {
 			bool exceptionCaught = false;
 
-			try
-			{
+			try {
 				var validator = new InlineValidator<Person> {
 					v => v.RuleFor(x => x.Surname).NotNull().WithSeverity(Severity.Warning),
 					v => v.RuleFor(x => x.Surname).NotNull().WithSeverity(Severity.Error),

--- a/src/FluentValidation/TestHelper/ValidatorTestExtensions.cs
+++ b/src/FluentValidation/TestHelper/ValidatorTestExtensions.cs
@@ -133,9 +133,7 @@ namespace FluentValidation.TestHelper {
 
 			if (!anyMatched) {
 				var failure = failures.FirstOrDefault();
-
 				string message = BuildErrorMessage(failure, exceptionMessage, "Expected validation error was not found");
-
 				throw new ValidationTestException(message);
 			}
 			
@@ -148,9 +146,7 @@ namespace FluentValidation.TestHelper {
 			if (!allMatched)
 			{
 				var failure = failures.First(fail => !(failurePredicate(fail)));
-
 				string message = BuildErrorMessage(failure, exceptionMessage, "Unexpected validation error was found");
-
 				throw new ValidationTestException(message);
 			}
 

--- a/src/FluentValidation/TestHelper/ValidatorTestExtensions.cs
+++ b/src/FluentValidation/TestHelper/ValidatorTestExtensions.cs
@@ -118,8 +118,7 @@ namespace FluentValidation.TestHelper {
 		}
 
 		private static string BuildErrorMessage(ValidationFailure failure, string exceptionMessage, string defaultMessage) {
-			if (exceptionMessage != null && failure != null)
-			{
+			if (exceptionMessage != null && failure != null) {
 				return exceptionMessage.Replace("{Code}", failure.ErrorCode)
 					.Replace("{Message}", failure.ErrorMessage)
 					.Replace("{State}", failure.CustomState?.ToString() ?? "")
@@ -143,8 +142,7 @@ namespace FluentValidation.TestHelper {
 		public static IEnumerable<ValidationFailure> WhenAll(this IEnumerable<ValidationFailure> failures, Func<ValidationFailure, bool> failurePredicate, string exceptionMessage = null) {
 			bool allMatched = failures.All(failurePredicate);
 
-			if (!allMatched)
-			{
+			if (!allMatched) {
 				var failure = failures.First(fail => !(failurePredicate(fail)));
 				string message = BuildErrorMessage(failure, exceptionMessage, "Unexpected validation error was found");
 				throw new ValidationTestException(message);

--- a/src/FluentValidation/TestHelper/ValidatorTestExtensions.cs
+++ b/src/FluentValidation/TestHelper/ValidatorTestExtensions.cs
@@ -117,8 +117,7 @@ namespace FluentValidation.TestHelper {
 			testValidationResult.Which.ShouldNotHaveValidationError();
 		}
 
-		private static string BuildErrorMessage(ValidationFailure failure, string exceptionMessage, string defaultMessage)
-		{
+		private static string BuildErrorMessage(ValidationFailure failure, string exceptionMessage, string defaultMessage) {
 			if (exceptionMessage != null && failure != null)
 			{
 				return exceptionMessage.Replace("{Code}", failure.ErrorCode)

--- a/src/FluentValidation/TestHelper/ValidatorTestExtensions.cs
+++ b/src/FluentValidation/TestHelper/ValidatorTestExtensions.cs
@@ -144,7 +144,7 @@ namespace FluentValidation.TestHelper {
 
 			if (!allMatched) {
 				var failure = failures.First(fail => !(failurePredicate(fail)));
-				string message = BuildErrorMessage(failure, exceptionMessage, "Unexpected validation error was found");
+				string message = BuildErrorMessage(failure, exceptionMessage, "Found an unexpected validation error");
 				throw new ValidationTestException(message);
 			}
 
@@ -168,19 +168,19 @@ namespace FluentValidation.TestHelper {
 		}
 
 		public static IEnumerable<ValidationFailure> WithoutSeverity(this IEnumerable<ValidationFailure> failures, Severity unexpectedSeverity) {
-			return failures.WhenAll(failure => failure.Severity != unexpectedSeverity, string.Format("Unexpected a severity of '{0}'", unexpectedSeverity));
+			return failures.WhenAll(failure => failure.Severity != unexpectedSeverity, string.Format("Found an unexpected severity of '{0}'", unexpectedSeverity));
 		}
 
 		public static IEnumerable<ValidationFailure> WithoutCustomState(this IEnumerable<ValidationFailure> failures, object unexpectedCustomState) {
-			return failures.WhenAll(failure => failure.CustomState != unexpectedCustomState, string.Format("Unexpected custom state of '{0}'", unexpectedCustomState));
+			return failures.WhenAll(failure => failure.CustomState != unexpectedCustomState, string.Format("Found an unexpected custom state of '{0}'", unexpectedCustomState));
 		}
 
 		public static IEnumerable<ValidationFailure> WithoutErrorMessage(this IEnumerable<ValidationFailure> failures, string unexpectedErrorMessage) {
-			return failures.WhenAll(failure => failure.ErrorMessage != unexpectedErrorMessage, string.Format("Unexpected an error message of '{0}'", unexpectedErrorMessage));
+			return failures.WhenAll(failure => failure.ErrorMessage != unexpectedErrorMessage, string.Format("Found an unexpected error message of '{0}'", unexpectedErrorMessage));
 		}
 
 		public static IEnumerable<ValidationFailure> WithoutErrorCode(this IEnumerable<ValidationFailure> failures, string unexpectedErrorCode) {
-			return failures.WhenAll(failure => failure.ErrorCode != unexpectedErrorCode, string.Format("Unexpected an error code of '{0}'", unexpectedErrorCode));
+			return failures.WhenAll(failure => failure.ErrorCode != unexpectedErrorCode, string.Format("Found an unexpected error code of '{0}'", unexpectedErrorCode));
 		}
 	}
 }


### PR DESCRIPTION
Hello!

Today I discovered the presence of extensions for tests with the **`with`** conditions, but did not find the **`without`** conditions.

```csharp

                public static IEnumerable<ValidationFailure> WithoutSeverity(this IEnumerable<ValidationFailure> failures, Severity unexpectedSeverity) {
			return failures.WhenAll(failure => failure.Severity != unexpectedSeverity, string.Format("Unexpected a severity of '{0}'", unexpectedSeverity));
		}

		public static IEnumerable<ValidationFailure> WithoutCustomState(this IEnumerable<ValidationFailure> failures, object unexpectedCustomState) {
			return failures.WhenAll(failure => failure.CustomState != unexpectedCustomState, string.Format("Unexpected custom state of '{0}'", unexpectedCustomState));
		}

		public static IEnumerable<ValidationFailure> WithoutErrorMessage(this IEnumerable<ValidationFailure> failures, string unexpectedErrorMessage) {
			return failures.WhenAll(failure => failure.ErrorMessage != unexpectedErrorMessage, string.Format("Unexpected an error message of '{0}'", unexpectedErrorMessage));
		}

		public static IEnumerable<ValidationFailure> WithoutErrorCode(this IEnumerable<ValidationFailure> failures, string unexpectedErrorCode) {
			return failures.WhenAll(failure => failure.ErrorCode != unexpectedErrorCode, string.Format("Unexpected an error code of '{0}'", unexpectedErrorCode));
		}


```


```csharp

			if (!anyMatched) {
				var failure = failures.FirstOrDefault();

```

```csharp

                BuildErrorMessage(ValidationFailure failure, string exceptionMessage, string defaultMessage)
		{
			if (exceptionMessage != null && failure != null)
			{
				return exceptionMessage.Replace("{Code}", failure.ErrorCode)
					.Replace("{Message}", failure.ErrorMessage)
					.Replace("{State}", failure.CustomState?.ToString() ?? "")
					.Replace("{Severity}", failure.Severity.ToString());
			}
			return defaultMessage;
		}

```