### PR TITLE
Allow registering multiple assemblies with one call

### DIFF
--- a/src/FluentValidation.AspNetCore/FluentValidationMvcConfiguration.cs
+++ b/src/FluentValidation.AspNetCore/FluentValidationMvcConfiguration.cs
@@ -81,6 +81,15 @@ namespace FluentValidation.AspNetCore {
 		}
 
 		/// <summary>
+		/// Registers all validators derived from AbstractValidator within the specified assemblies
+		/// </summary>
+		public FluentValidationMvcConfiguration RegisterValidatorsFromAssemblies(IEnumerable<Assembly> assemblies) {
+			ValidatorFactoryType = typeof(ServiceProviderValidatorFactory);
+			AssembliesToRegister.AddRange(assemblies);
+			return this;
+		}
+
+		/// <summary>
 		/// Configures clientside validation support
 		/// </summary>
 		/// <param name="clientsideConfig"></param>


### PR DESCRIPTION
Currently registering several assemblies requires calling `RegisterValidatorsFromAssembly(...)` several times. If you already have a list of the assemblies it would be cleaner to register the whole list of assemblies with a single call.

This PR introduces `RegisterValidatorsFromAssemblies(IEnumerable<Assembly> assemblies)` that allows you to register several assemblies with a single call.