### PR TITLE
Lazily load languages rather than pre-loading all languages

### DIFF
--- a/src/FluentValidation/FluentValidation.csproj
+++ b/src/FluentValidation/FluentValidation.csproj
@@ -85,6 +85,10 @@ Full release notes can be found at https://github.com/JeremySkinner/FluentValida
     <DelaySign>False</DelaySign>
     <DocumentationFile Condition="'$(Configuration)'=='Release'">bin\$(Configuration)\$(TargetFramework)\FluentValidation.xml</DocumentationFile>
     <DebugType>embedded</DebugType>
+    <LangVersion>8</LangVersion>
+  </PropertyGroup>
+  <PropertyGroup>
+    <NoWarn>1701;1702;1705;1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\CommonAssemblyInfo.cs" Link="CommonAssemblyInfo.cs" />

--- a/src/FluentValidation/Resources/Language.cs
+++ b/src/FluentValidation/Resources/Language.cs
@@ -54,9 +54,7 @@ namespace FluentValidation.Resources {
 		/// <param name="key"></param>
 		/// <returns></returns>
 		public virtual string GetTranslation(string key) {
-			string value;
-
-			if (_translations.TryGetValue(key, out value)) {
+			if (_translations.TryGetValue(key, out var value)) {
 				return value;
 			}
 

--- a/src/FluentValidation/Resources/Language.cs
+++ b/src/FluentValidation/Resources/Language.cs
@@ -1,18 +1,18 @@
 #region License
 // Copyright (c) Jeremy Skinner (http://www.jeremyskinner.co.uk)
-// 
-// Licensed under the Apache License, Version 2.0 (the "License"); 
-// you may not use this file except in compliance with the License. 
-// You may obtain a copy of the License at 
-// 
-// http://www.apache.org/licenses/LICENSE-2.0 
-// 
-// Unless required by applicable law or agreed to in writing, software 
-// distributed under the License is distributed on an "AS IS" BASIS, 
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
-// See the License for the specific language governing permissions and 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // The latest version of this file can be found at https://github.com/JeremySkinner/FluentValidation
 #endregion
 namespace FluentValidation.Resources {
@@ -38,7 +38,7 @@ namespace FluentValidation.Resources {
 		public virtual void Translate(string key, string message) {
 			_translations[key] = message;
 		}
-		
+
 		/// <summary>
 		/// Adds a translation for a type
 		/// </summary>

--- a/src/FluentValidation/Resources/LanguageManager.cs
+++ b/src/FluentValidation/Resources/LanguageManager.cs
@@ -17,6 +17,7 @@
 #endregion
 namespace FluentValidation.Resources {
 	using System;
+	using System.Collections.Concurrent;
 	using System.Collections.Generic;
 	using System.Globalization;
 	using Validators;
@@ -25,53 +26,60 @@ namespace FluentValidation.Resources {
 	/// Allows the default error message translations to be managed.
 	/// </summary>
 	public class LanguageManager : ILanguageManager {
-		private readonly Dictionary<string, Language> _languages = new Dictionary<string, Language>();
-		private Language _fallback;
+		private readonly ConcurrentDictionary<string, Language> _languages;
+		private readonly Language _fallback = new EnglishLanguage();
 
 		/// <summary>
 		/// Creates a new instance of the LanguageManager class.
 		/// </summary>
 		public LanguageManager() {
-			var languages = new Language[] {
-				new EnglishLanguage(),
-				new ChineseSimplifiedLanguage(),
-				new ChineseTraditionalLanguage(),
-				new CroatianLanguage(),
-				new CzechLanguage(),
-				new DanishLanguage(),
-				new DutchLanguage(),
-				new FinnishLanguage(),
-				new FrenchLanguage(),
-				new GermanLanguage(),
-				new GeorgianLanguage(),
-				new HebrewLanguage(),
-				new HindiLanguage(),
-				new ItalianLanguage(),
-				new KoreanLanguage(),
-				new MacedonianLanguage(),
-				new PersianLanguage(),
-				new PolishLanguage(),
-				new PortugueseLanguage(),
-				new PortugueseBrazilLanguage(),
-				new RomanianLanguage(),
-				new RussianLanguage(),
-				new SlovakLanguage(),
-				new SpanishLanguage(),
-				new SwedishLanguage(),
-				new TurkishLanguage(),
-				new UkrainianLanguage(),
-				new ArabicLanguage(),
-				new AlbanianLanguage(),
-				new GreekLanguage(),
-				new NorwegianBokmalLanguage(),
-				new JapaneseLanguage(),
+			// Initialize with English as the default. Others will be lazily loaded as needed.
+			_languages = new ConcurrentDictionary<string, Language>(new[] {
+				new KeyValuePair<string, Language>(EnglishLanguage.Culture, _fallback),
+			});
+		}
+		
+		/// <summary>
+		/// Language factory.
+		/// </summary>
+		/// <param name="culture">The culture code.</param>
+		/// <returns>The corresponding Language instance or null.</returns>
+		private static Language CreateLanguage(string culture) {
+			return culture switch {
+				EnglishLanguage.Culture => new EnglishLanguage(),
+				AlbanianLanguage.Culture => new AlbanianLanguage(),
+				ArabicLanguage.Culture => new ArabicLanguage(),
+				ChineseSimplifiedLanguage.Culture => new ChineseSimplifiedLanguage(),
+				ChineseTraditionalLanguage.Culture => new ChineseTraditionalLanguage(),
+				CroatianLanguage.Culture => new CroatianLanguage(),
+				CzechLanguage.Culture => new CzechLanguage(),
+				DanishLanguage.Culture => new DanishLanguage(),
+				DutchLanguage.Culture => new DutchLanguage(),
+				FinnishLanguage.Culture => new FinnishLanguage(),
+				FrenchLanguage.Culture => new FrenchLanguage(),
+				GermanLanguage.Culture => new GermanLanguage(),
+				GeorgianLanguage.Culture => new GeorgianLanguage(),
+				GreekLanguage.Culture => new GreekLanguage(),
+				HebrewLanguage.Culture => new HebrewLanguage(),
+				HindiLanguage.Culture => new HindiLanguage(),
+				ItalianLanguage.Culture => new ItalianLanguage(),
+				JapaneseLanguage.Culture => new JapaneseLanguage(),
+				KoreanLanguage.Culture => new KoreanLanguage(),
+				MacedonianLanguage.Culture => new MacedonianLanguage(),
+				NorwegianBokmalLanguage.Culture => new NorwegianBokmalLanguage(),
+				PersianLanguage.Culture => new PersianLanguage(),
+				PolishLanguage.Culture => new PolishLanguage(),
+				PortugueseLanguage.Culture => new PortugueseLanguage(),
+				PortugueseBrazilLanguage.Culture => new PortugueseBrazilLanguage(),
+				RomanianLanguage.Culture => new RomanianLanguage(),
+				RussianLanguage.Culture => new RussianLanguage(),
+				SlovakLanguage.Culture => new SlovakLanguage(),
+				SpanishLanguage.Culture => new SpanishLanguage(),
+				SwedishLanguage.Culture => new SwedishLanguage(),
+				TurkishLanguage.Culture => new TurkishLanguage(),
+				UkrainianLanguage.Culture => new UkrainianLanguage(),
+				_=> (Language)null,
 			};
-
-			foreach (var language in languages) {
-				_languages[language.Name] = language;
-			}
-
-			_fallback = _languages["en"];
 		}
 
 		/// <summary>
@@ -83,15 +91,6 @@ namespace FluentValidation.Resources {
 		/// Default culture to use for all requests to the LanguageManager. If not specified, uses the current UI culture.
 		/// </summary>
 		public CultureInfo Culture { get; set; }
-
-		/// <summary>
-		/// Provides a collection of all supported languages.
-		/// </summary>
-		/// <returns></returns>
-		[Obsolete("LanguageManager.GetSupportedLanguages() will be removed in FluentValidation 9.0 as it assumes that all languages are pre-loaded.")]
-		public IEnumerable<string> GetSupportedLanguages() {
-			return _languages.Keys;
-		}
 
 		/// <summary>
 		/// Removes all languages except the default.
@@ -110,18 +109,10 @@ namespace FluentValidation.Resources {
 		public virtual string GetString(string key, CultureInfo culture=null) {
 			culture = culture ?? Culture ?? CultureInfo.CurrentUICulture;
 
-			string code = culture.Name;
-
-			if (!culture.IsNeutralCulture && !_languages.ContainsKey(code)) {
-				code = culture.Parent.Name;
-			}
-
-			var languageToUse = Enabled && _languages.ContainsKey(code)
-				? _languages[code]
-				: _fallback;
-
+			var languageToUse = GetCachedLanguage(culture);
 			string value = languageToUse.GetTranslation(key);
 
+			// Selected language is missing a translation for this key - fall back to English translation. 
 			if (string.IsNullOrEmpty(value) && languageToUse != _fallback) {
 				value = _fallback.GetTranslation(key);
 			}
@@ -129,7 +120,25 @@ namespace FluentValidation.Resources {
 			return value ?? string.Empty;
 		}
 
-		[Obsolete("LanguageManager.GetSupportedTranslationKeys() can return inconsistent information depending on the current culture. This method will be removed in 9.0.")]
+		private Language GetCachedLanguage(CultureInfo culture) {
+			// If the language manager is enabled, try and find matching translations.
+			if (Enabled) {
+				var languageToUse = _languages.GetOrAdd(culture.Name, CreateLanguage);
+
+				// If we couldn't find translations for this culture, and it's not a neutral culture
+				// then try and find translations for the parent culture instead.
+				if (languageToUse == null && !culture.IsNeutralCulture) {
+					languageToUse = _languages.GetOrAdd(culture.Parent.Name, CreateLanguage);
+				}
+
+				if (languageToUse != null) {
+					return languageToUse;
+				}
+			}
+
+			return _fallback;
+		}
+
 		public IEnumerable<string> GetSupportedTranslationKeys() {
 			return _fallback.GetSupportedKeys();
 		}
@@ -144,7 +153,7 @@ namespace FluentValidation.Resources {
 			}
 
 			_languages[language].Translate(key, message);
-
 		}
+
 	}
 }


### PR DESCRIPTION
The vast majority of applications will only operate in a single language, so pre-loading everything seems unnecessary. Switches from pre-loading all languages to lazily-loading all languages except English. 