### PR TITLE
Fixed typo in word sensitive

### DIFF
--- a/docs/_doc/validators/built-in-validators.md
+++ b/docs/_doc/validators/built-in-validators.md
@@ -305,7 +305,7 @@ String format args:
 Checks whether a string is a valid enum name. 
 
 ```csharp
-// For a case sensiitive comparison
+// For a case sensitive comparison
 RuleFor(x => x.ErrorLevelName).IsEnumName(typeof(ErrorLevel));
 
 // For a case-insensitive comparison


### PR DESCRIPTION
A simple typo

sensiitive ->sensitive

Also I'm not sure why last the other line is marked. Could be due to different line endings?