### PR TITLE
Adding dynamic Severity

### DIFF
--- a/src/FluentValidation.Tests/UserSeverityTester.cs
+++ b/src/FluentValidation.Tests/UserSeverityTester.cs
@@ -84,5 +84,15 @@ namespace FluentValidation.Tests {
 			result = validator.Validate(person);
 			result.Errors[0].Severity.ShouldEqual(Severity.Info);
 		}
+
+		[Fact]
+		public void Should_use_last_supplied_severity() {
+			validator.RuleFor(x => x.Surname).NotNull().WithSeverity(x => Severity.Warning).WithSeverity(Severity.Info);
+
+			var person = new Person();
+
+			var result = validator.Validate(person);
+			result.Errors[0].Severity.ShouldEqual(Severity.Info);
+		}
 	}
 }

--- a/src/FluentValidation.Tests/UserSeverityTester.cs
+++ b/src/FluentValidation.Tests/UserSeverityTester.cs
@@ -77,16 +77,12 @@ namespace FluentValidation.Tests {
 
 			var person = new Person();
 
-			{
-				var result = validator.Validate(person);
-				result.Errors[0].Severity.ShouldEqual(Severity.Warning);
-			}
+			var result = validator.Validate(person);
+			result.Errors[0].Severity.ShouldEqual(Severity.Warning);
 
-			{
-				person.Age = 100;
-				var result = validator.Validate(person);
-				result.Errors[0].Severity.ShouldEqual(Severity.Info);
-			}
+			person.Age = 100;
+			result = validator.Validate(person);
+			result.Errors[0].Severity.ShouldEqual(Severity.Info);
 		}
 	}
 }

--- a/src/FluentValidation.Tests/UserSeverityTester.cs
+++ b/src/FluentValidation.Tests/UserSeverityTester.cs
@@ -1,30 +1,29 @@
 #region License
 // Copyright (c) Jeremy Skinner (http://www.jeremyskinner.co.uk)
-// 
-// Licensed under the Apache License, Version 2.0 (the "License"); 
-// you may not use this file except in compliance with the License. 
-// You may obtain a copy of the License at 
-// 
-// http://www.apache.org/licenses/LICENSE-2.0 
-// 
-// Unless required by applicable law or agreed to in writing, software 
-// distributed under the License is distributed on an "AS IS" BASIS, 
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
-// See the License for the specific language governing permissions and 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // The latest version of this file can be found at https://github.com/jeremyskinner/FluentValidation
 #endregion
 
 namespace FluentValidation.Tests {
 	using System;
+	using System.Collections.Generic;
 	using System.Linq;
 	using Xunit;
 
-	
 	public class UserSeverityTester {
 		TestValidator validator;
-
 
 		public UserSeverityTester()
 		{
@@ -43,6 +42,51 @@ namespace FluentValidation.Tests {
 		    validator.RuleFor( x => x.Surname ).NotNull();
 		    var result = validator.Validate( new Person() );
 		    result.Errors.Single().Severity.ShouldEqual( Severity.Error );
+		}
+
+		[Fact]
+		public void Throws_when_provider_is_null() {
+			typeof(ArgumentNullException).ShouldBeThrownBy(() => validator.RuleFor(x => x.Surname).NotNull().WithSeverity((Func<Person, Severity>) null));
+		}
+
+		[Fact]
+		public void Correctly_provides_object_being_validated() {
+			Person resultPerson = null;
+
+			validator.RuleFor(x => x.Surname).NotNull().WithSeverity(x => {
+				resultPerson = x;
+				return Severity.Warning;
+			});
+
+			var person = new Person();
+			validator.Validate(person);
+
+			resultPerson.ShouldBeTheSameAs(person);
+		}
+
+		[Fact]
+		public void Can_Provide_severity_for_item_in_collection() {
+			validator.RuleForEach(x => x.Children).NotNull().WithSeverity((person, child) => Severity.Warning);
+			var result = validator.Validate(new Person {Children = new List<Person> {null}});
+			result.Errors[0].Severity.ShouldEqual(Severity.Warning);
+		}
+
+		[Fact]
+		public void Can_Provide_conditional_severity() {
+			validator.RuleFor(x => x.Surname).NotNull().WithSeverity(x => x.Age > 10 ? Severity.Info : Severity.Warning);
+
+			var person = new Person();
+
+			{
+				var result = validator.Validate(person);
+				result.Errors[0].Severity.ShouldEqual(Severity.Warning);
+			}
+
+			{
+				person.Age = 100;
+				var result = validator.Validate(person);
+				result.Errors[0].Severity.ShouldEqual(Severity.Info);
+			}
 		}
 	}
 }

--- a/src/FluentValidation/DefaultValidatorOptions.cs
+++ b/src/FluentValidation/DefaultValidatorOptions.cs
@@ -383,6 +383,38 @@ namespace FluentValidation {
 		}
 
 		/// <summary>
+		/// Specifies custom severity that should be stored alongside the validation message when validation fails for this rule.
+		/// </summary>
+		/// <typeparam name="T"></typeparam>
+		/// <typeparam name="TProperty"></typeparam>
+		/// <param name="rule"></param>
+		/// <param name="severityProvider"></param>
+		/// <returns></returns>
+		public static IRuleBuilderOptions<T, TProperty> WithSeverity<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, Func<T, Severity> severityProvider) {
+			severityProvider.Guard("A lambda expression must be passed to WithSeverity", nameof(severityProvider));
+			var wrapper = new Func<PropertyValidatorContext, Severity>(ctx => severityProvider((T) ctx.Instance));
+			return rule.Configure(config => config.CurrentValidator.Options.CustomSeverityProvider = wrapper);
+		}
+
+		/// <summary>
+		/// Specifies custom severity that should be stored alongside the validation message when validation fails for this rule.
+		/// </summary>
+		/// <typeparam name="T"></typeparam>
+		/// <typeparam name="TProperty"></typeparam>
+		/// <param name="rule"></param>
+		/// <param name="severityProvider"></param>
+		/// <returns></returns>
+		public static IRuleBuilderOptions<T, TProperty> WithSeverity<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, Func<T, TProperty, Severity> severityProvider) {
+			severityProvider.Guard("A lambda expression must be passed to WithSeverity", nameof(severityProvider));
+
+			var wrapper = new Func<PropertyValidatorContext, Severity>(ctx => {
+				return severityProvider((T) ctx.Instance, (TProperty) ctx.PropertyValue);
+			});
+
+			return rule.Configure(config => config.CurrentValidator.Options.CustomSeverityProvider = wrapper);
+		}
+
+		/// <summary>
 		/// Specifies custom method that will be called when specific rule fails
 		/// </summary>
 		/// <typeparam name="T"></typeparam>

--- a/src/FluentValidation/DefaultValidatorOptions.cs
+++ b/src/FluentValidation/DefaultValidatorOptions.cs
@@ -379,7 +379,7 @@ namespace FluentValidation {
 		/// <param name="severity"></param>
 		/// <returns></returns>
 		public static IRuleBuilderOptions<T, TProperty> WithSeverity<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, Severity severity) {
-			return rule.Configure(config => config.CurrentValidator.Options.CustomSeverityProvider = (x) => severity);
+			return rule.Configure(config => config.CurrentValidator.Options.SeverityProvider = (x) => severity);
 		}
 
 		/// <summary>
@@ -393,7 +393,7 @@ namespace FluentValidation {
 		public static IRuleBuilderOptions<T, TProperty> WithSeverity<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, Func<T, Severity> severityProvider) {
 			severityProvider.Guard("A lambda expression must be passed to WithSeverity", nameof(severityProvider));
 			var wrapper = new Func<PropertyValidatorContext, Severity>(ctx => severityProvider((T) ctx.Instance));
-			return rule.Configure(config => config.CurrentValidator.Options.CustomSeverityProvider = wrapper);
+			return rule.Configure(config => config.CurrentValidator.Options.SeverityProvider = wrapper);
 		}
 
 		/// <summary>
@@ -411,7 +411,7 @@ namespace FluentValidation {
 				return severityProvider((T) ctx.Instance, (TProperty) ctx.PropertyValue);
 			});
 
-			return rule.Configure(config => config.CurrentValidator.Options.CustomSeverityProvider = wrapper);
+			return rule.Configure(config => config.CurrentValidator.Options.SeverityProvider = wrapper);
 		}
 
 		/// <summary>

--- a/src/FluentValidation/DefaultValidatorOptions.cs
+++ b/src/FluentValidation/DefaultValidatorOptions.cs
@@ -83,7 +83,7 @@ namespace FluentValidation {
 			});
 		}
 
-		
+
 		/// <summary>
 		/// Specifies a custom action to be invoked when the validator fails.
 		/// </summary>
@@ -98,7 +98,7 @@ namespace FluentValidation {
 				config.OnFailure = (x, failures) => onFailure((T)x);
 			});
 		}
-		
+
 		/// <summary>
 		/// Specifies a custom action to be invoked when the validator fails.
 		/// </summary>
@@ -394,7 +394,7 @@ namespace FluentValidation {
 			severityProvider.Guard("A lambda expression must be passed to WithSeverity", nameof(severityProvider));
 
 			Severity SeverityProvider(PropertyValidatorContext ctx) {
-				return severityProvider((T)ctx.Instance);
+				return severityProvider((T)ctx.InstanceToValidate);
 			}
 
 			return rule.Configure(config => config.CurrentValidator.Options.SeverityProvider = SeverityProvider);
@@ -412,7 +412,7 @@ namespace FluentValidation {
 			severityProvider.Guard("A lambda expression must be passed to WithSeverity", nameof(severityProvider));
 
 			Severity SeverityProvider(PropertyValidatorContext ctx) {
-				return severityProvider((T)ctx.Instance, (TProperty)ctx.PropertyValue);
+				return severityProvider((T)ctx.InstanceToValidate, (TProperty)ctx.PropertyValue);
 			}
 
 			return rule.Configure(config => config.CurrentValidator.Options.SeverityProvider = SeverityProvider);

--- a/src/FluentValidation/DefaultValidatorOptions.cs
+++ b/src/FluentValidation/DefaultValidatorOptions.cs
@@ -392,8 +392,12 @@ namespace FluentValidation {
 		/// <returns></returns>
 		public static IRuleBuilderOptions<T, TProperty> WithSeverity<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, Func<T, Severity> severityProvider) {
 			severityProvider.Guard("A lambda expression must be passed to WithSeverity", nameof(severityProvider));
-			var wrapper = new Func<PropertyValidatorContext, Severity>(ctx => severityProvider((T) ctx.Instance));
-			return rule.Configure(config => config.CurrentValidator.Options.SeverityProvider = wrapper);
+
+			Severity SeverityProvider(PropertyValidatorContext ctx) {
+				return severityProvider((T)ctx.Instance);
+			}
+
+			return rule.Configure(config => config.CurrentValidator.Options.SeverityProvider = SeverityProvider);
 		}
 
 		/// <summary>
@@ -407,11 +411,11 @@ namespace FluentValidation {
 		public static IRuleBuilderOptions<T, TProperty> WithSeverity<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, Func<T, TProperty, Severity> severityProvider) {
 			severityProvider.Guard("A lambda expression must be passed to WithSeverity", nameof(severityProvider));
 
-			var wrapper = new Func<PropertyValidatorContext, Severity>(ctx => {
-				return severityProvider((T) ctx.Instance, (TProperty) ctx.PropertyValue);
-			});
+			Severity SeverityProvider(PropertyValidatorContext ctx) {
+				return severityProvider((T)ctx.Instance, (TProperty)ctx.PropertyValue);
+			}
 
-			return rule.Configure(config => config.CurrentValidator.Options.SeverityProvider = wrapper);
+			return rule.Configure(config => config.CurrentValidator.Options.SeverityProvider = SeverityProvider);
 		}
 
 		/// <summary>

--- a/src/FluentValidation/DefaultValidatorOptions.cs
+++ b/src/FluentValidation/DefaultValidatorOptions.cs
@@ -379,7 +379,7 @@ namespace FluentValidation {
 		/// <param name="severity"></param>
 		/// <returns></returns>
 		public static IRuleBuilderOptions<T, TProperty> WithSeverity<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, Severity severity) {
-			return rule.Configure(config => config.CurrentValidator.Options.Severity = severity);
+			return rule.Configure(config => config.CurrentValidator.Options.CustomSeverityProvider = (x) => severity);
 		}
 
 		/// <summary>

--- a/src/FluentValidation/Results/ValidationFailure.cs
+++ b/src/FluentValidation/Results/ValidationFailure.cs
@@ -67,8 +67,8 @@ namespace FluentValidation.Results {
 		/// <summary>
 		/// Custom severity level associated with the failure.
 		/// </summary>
-		public Severity Severity { get; set; }
-		
+		public Severity Severity { get; set; } = Severity.Error;
+
 		/// <summary>
 		/// Gets or sets the error code.
 		/// </summary>

--- a/src/FluentValidation/ValidatorMetadata.cs
+++ b/src/FluentValidation/ValidatorMetadata.cs
@@ -77,7 +77,7 @@ namespace FluentValidation {
 		/// <summary>
 		/// Function used to retrieve the severity for the validator
 		/// </summary>
-		public Func<PropertyValidatorContext, Severity> CustomSeverityProvider { get; set; }
+		public Func<PropertyValidatorContext, Severity> SeverityProvider { get; set; }
 
 		/// <summary>
 		/// Retrieves the unformatted error message template.

--- a/src/FluentValidation/ValidatorMetadata.cs
+++ b/src/FluentValidation/ValidatorMetadata.cs
@@ -80,11 +80,6 @@ namespace FluentValidation {
 		public Func<PropertyValidatorContext, Severity> CustomSeverityProvider { get; set; }
 
 		/// <summary>
-		/// Severity of error.
-		/// </summary>
-		public Severity Severity { get; set; }
-
-		/// <summary>
 		/// Retrieves the unformatted error message template.
 		/// </summary>
 		public IStringSource ErrorMessageSource {

--- a/src/FluentValidation/ValidatorMetadata.cs
+++ b/src/FluentValidation/ValidatorMetadata.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 // Copyright (c) Jeremy Skinner (http://www.jeremyskinner.co.uk)
 // 
 // Licensed under the Apache License, Version 2.0 (the "License"); 
@@ -75,10 +75,15 @@ namespace FluentValidation {
 		public Func<PropertyValidatorContext, object> CustomStateProvider { get; set; }
 
 		/// <summary>
+		/// Function used to retrieve the severity for the validator
+		/// </summary>
+		public Func<PropertyValidatorContext, Severity> CustomSeverityProvider { get; set; }
+
+		/// <summary>
 		/// Severity of error.
 		/// </summary>
 		public Severity Severity { get; set; }
-		
+
 		/// <summary>
 		/// Retrieves the unformatted error message template.
 		/// </summary>

--- a/src/FluentValidation/Validators/PropertyValidator.cs
+++ b/src/FluentValidation/Validators/PropertyValidator.cs
@@ -108,8 +108,6 @@ namespace FluentValidation.Validators {
 				failure.CustomState = Options.CustomStateProvider(context);
 			}
 
-			failure.Severity = Options.Severity;
-
 			if (Options.CustomSeverityProvider != null) {
 				failure.Severity = Options.CustomSeverityProvider(context);
 			}

--- a/src/FluentValidation/Validators/PropertyValidator.cs
+++ b/src/FluentValidation/Validators/PropertyValidator.cs
@@ -108,8 +108,8 @@ namespace FluentValidation.Validators {
 				failure.CustomState = Options.CustomStateProvider(context);
 			}
 
-			if (Options.CustomSeverityProvider != null) {
-				failure.Severity = Options.CustomSeverityProvider(context);
+			if (Options.SeverityProvider != null) {
+				failure.Severity = Options.SeverityProvider(context);
 			}
 
 			return failure;

--- a/src/FluentValidation/Validators/PropertyValidator.cs
+++ b/src/FluentValidation/Validators/PropertyValidator.cs
@@ -109,6 +109,11 @@ namespace FluentValidation.Validators {
 			}
 
 			failure.Severity = Options.Severity;
+
+			if (Options.CustomSeverityProvider != null) {
+				failure.Severity = Options.CustomSeverityProvider(context);
+			}
+
 			return failure;
 		}
 	}


### PR DESCRIPTION
This PR adds the ability to use a dynamic severity the same way we can use dynamic custom state by using a provider instead of a fixed value.

Use case:
We used custom state before severity existed in FluentValidation to do the same.
Our validators then created either a warning or an error depending on various conditions like "Does the user have a license to use this feature?" if he does the validation resulted in a warning, if he didn't the validation resulted in an error.