### PR TITLE
Move condition checks into the rule instance

### DIFF
--- a/src/FluentValidation.Tests/ForEachRuleTests.cs
+++ b/src/FluentValidation.Tests/ForEachRuleTests.cs
@@ -500,6 +500,35 @@ namespace FluentValidation.Tests {
 			result.Errors[0].ErrorMessage.ShouldEqual("1");
 		}
 
+		[Fact]
+		public void When_runs_outside_RuleForEach_loop() {
+			// Shouldn't throw an exception if the condition is run outside the loop.
+			var validator = new InlineValidator<Tuple<Person>>();
+			validator.RuleForEach(x => x.Item1.Orders).Must(x => false)
+				.When(x => x.Item1 != null);
+
+			var result = validator.Validate(Tuple.Create((Person) null));
+			result.IsValid.ShouldBeTrue();
+
+			result = validator.Validate(Tuple.Create(new Person() { Orders = new List<Order> { new Order() }}));
+			result.IsValid.ShouldBeFalse();
+		}
+
+		[Fact]
+		public async Task When_runs_outside_RuleForEach_loop_async() {
+			// Shouldn't throw an exception if the condition is run outside the loop.
+			var validator = new InlineValidator<Tuple<Person>>();
+			validator.RuleForEach(x => x.Item1.Orders)
+				.MustAsync((x,c) => Task.FromResult(false))
+				.When(x => x.Item1 != null);
+
+			var result =	await validator.ValidateAsync(Tuple.Create((Person) null));
+			result.IsValid.ShouldBeTrue();
+
+			result = await validator.ValidateAsync(Tuple.Create(new Person() { Orders = new List<Order> { new Order() }}));
+			result.IsValid.ShouldBeFalse();
+		}
+
 		public class OrderValidator : AbstractValidator<Order> {
 			public OrderValidator() {
 				RuleFor(x => x.ProductName).NotEmpty();

--- a/src/FluentValidation.Tests/RuleBuilderTests.cs
+++ b/src/FluentValidation.Tests/RuleBuilderTests.cs
@@ -1,18 +1,18 @@
 #region License
 // Copyright (c) Jeremy Skinner (http://www.jeremyskinner.co.uk)
-// 
-// Licensed under the Apache License, Version 2.0 (the "License"); 
-// you may not use this file except in compliance with the License. 
-// You may obtain a copy of the License at 
-// 
-// http://www.apache.org/licenses/LICENSE-2.0 
-// 
-// Unless required by applicable law or agreed to in writing, software 
-// distributed under the License is distributed on an "AS IS" BASIS, 
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
-// See the License for the specific language governing permissions and 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // The latest version of this file can be found at https://github.com/jeremyskinner/FluentValidation
 #endregion
 
@@ -29,7 +29,7 @@ namespace FluentValidation.Tests {
 	using Results;
 	using Validators;
 	using System.Reflection;
-	
+
 	public class RuleBuilderTests {
 		RuleBuilder<Person, string> builder;
 
@@ -123,6 +123,7 @@ namespace FluentValidation.Tests {
 		public void Calling_validate_should_delegate_to_underlying_validator() {
 			var person = new Person {Surname = "Foo"};
 			var validator = new Mock<IPropertyValidator>();
+			validator.Setup(x => x.Options).Returns(new PropertyValidatorOptions());
 			builder.SetValidator(validator.Object);
 
 			builder.Rule.Validate(new ValidationContext<Person>(person, new PropertyChain(), new DefaultValidatorSelector())).ToList();
@@ -134,6 +135,7 @@ namespace FluentValidation.Tests {
 		public async Task Calling_ValidateAsync_should_delegate_to_underlying_sync_validator() {
 			var person = new Person { Surname = "Foo" };
 			var validator = new Mock<IPropertyValidator>();
+			validator.Setup(x => x.Options).Returns(new PropertyValidatorOptions());
 			builder.SetValidator(validator.Object);
 
 			await builder.Rule.ValidateAsync(new ValidationContext<Person>(person, new PropertyChain(), new DefaultValidatorSelector()), new CancellationToken());
@@ -158,7 +160,7 @@ namespace FluentValidation.Tests {
 			validator.Verify(x => x.ValidateAsync(It.Is<PropertyValidatorContext>(c => (string)c.PropertyValue == "Foo"), It.IsAny<CancellationToken>()));
 
 		}
-       
+
 
 		[Fact]
 		public void PropertyDescription_should_return_property_name_split() {
@@ -230,7 +232,7 @@ namespace FluentValidation.Tests {
 
 		class TestPropertyValidator : PropertyValidator {
 			public TestPropertyValidator() : base(new LanguageStringSource(nameof(NotNullValidator))) {
-				
+
 			}
 
 			protected override bool IsValid(PropertyValidatorContext context) {

--- a/src/FluentValidation/Internal/CollectionPropertyRule.cs
+++ b/src/FluentValidation/Internal/CollectionPropertyRule.cs
@@ -81,6 +81,10 @@ namespace FluentValidation.Internal {
 			}
 
 			var propertyContext = new PropertyValidatorContext(context, this, propertyName);
+
+			if (validator.Options.Condition != null && !validator.Options.Condition(propertyContext)) return Enumerable.Empty<ValidationFailure>();
+			if (validator.Options.AsyncCondition != null && !await validator.Options.AsyncCondition(propertyContext, cancellation)) return Enumerable.Empty<ValidationFailure>();
+
 			var collectionPropertyValue = propertyContext.PropertyValue as IEnumerable<TProperty>;
 
 			if (collectionPropertyValue != null) {
@@ -146,6 +150,9 @@ namespace FluentValidation.Internal {
 			}
 
 			var propertyContext = new PropertyValidatorContext(context, this, propertyName);
+
+			if (validator.Options.Condition != null && !validator.Options.Condition(propertyContext)) return Enumerable.Empty<ValidationFailure>();
+
 			var results = new List<ValidationFailure>();
 			var collectionPropertyValue = propertyContext.PropertyValue as IEnumerable<TProperty>;
 

--- a/src/FluentValidation/Validators/PropertyValidator.cs
+++ b/src/FluentValidation/Validators/PropertyValidator.cs
@@ -52,7 +52,6 @@ namespace FluentValidation.Validators {
 		}
 
 		public virtual IEnumerable<ValidationFailure> Validate(PropertyValidatorContext context) {
-			if (Options.Condition != null && !Options.Condition(context)) return Enumerable.Empty<ValidationFailure>();
 			if (IsValid(context)) return Enumerable.Empty<ValidationFailure>();
 
 			PrepareMessageFormatterForValidationError(context);
@@ -61,8 +60,6 @@ namespace FluentValidation.Validators {
 		}
 
 		public virtual async Task<IEnumerable<ValidationFailure>> ValidateAsync(PropertyValidatorContext context, CancellationToken cancellation) {
-			if (Options.Condition != null && !Options.Condition(context)) return Enumerable.Empty<ValidationFailure>();
-			if (Options.AsyncCondition != null && !await Options.AsyncCondition(context, cancellation)) return Enumerable.Empty<ValidationFailure>();
 			if (await IsValidAsync(context, cancellation)) return Enumerable.Empty<ValidationFailure>();
 
 			PrepareMessageFormatterForValidationError(context);


### PR DESCRIPTION
Conditions set by `When/WhenAsync/Unless/UnlessAsync` are currently checked by the `PropertyValidator` instance associated with the check. This PR moves the responsibility for running the check out of the property validator instance and into the parent rule instance. 

This will fix #1195 as it means that for collection rules, the condition is run outside of the loop

Things to consider:
- Would anyone be relying on the previous behaviour of the condition running multiple times (once per collection element)? I think probably not as we already have the `Where` method for filtering out individual collection elements. 
- Would anyone be calling Validate on the property validator instance manually, expecting conditions to be checked. Again I think probably not - noone should be running property validators directly.  
- This is *technically* a breaking change so maybe best for 9.0, rather than 8.5 