### PR TITLE
Bit more helpful info when testing Validators.

### DIFF
--- a/src/FluentValidation.Tests/ValidatorTesterTester.cs
+++ b/src/FluentValidation.Tests/ValidatorTesterTester.cs
@@ -270,7 +270,7 @@ namespace FluentValidation.Tests {
       });
 
       var ex = Assert.Throws<ValidationTestException>(() => result.ShouldHaveValidationErrorFor(x => x.NullableInt.Value));
-      Assert.Equal("Expected a validation error for property NullableInt.Value. Found 1 error for the properties: NullableInt.", ex.Message);
+      Assert.Equal("Expected a validation error for property NullableInt.Value\n----\nProperties with Validation Errors:\n[0]: NullableInt\n", ex.Message);
     }
 
     [Fact]
@@ -287,7 +287,7 @@ namespace FluentValidation.Tests {
       });
 
       var ex = Assert.Throws<ValidationTestException>(() => result.ShouldHaveValidationErrorFor(x => x.NullableInt.Value));
-      Assert.Equal("Expected a validation error for property NullableInt.Value. Found 3 errors for the properties: NullableInt, Age, AnotherInt.", ex.Message);
+      Assert.Equal("Expected a validation error for property NullableInt.Value\n----\nProperties with Validation Errors:\n[0]: NullableInt\n[1]: Age\n[2]: AnotherInt\n", ex.Message);
     }
 
     [Fact]

--- a/src/FluentValidation.Tests/ValidatorTesterTester.cs
+++ b/src/FluentValidation.Tests/ValidatorTesterTester.cs
@@ -261,17 +261,36 @@ namespace FluentValidation.Tests {
 		}
 
 		[Fact]
-		public void ShouldHaveValidationError_should_correctly_handle_explicitly_providing_object_to_validate() {
-			var unitOfMeasure = new UnitOfMeasure {
-				Value = 1
-			};
+		public void ShouldHaveValidationError_with_an_unmatched_rule_and_a_single_error_should_throw_an_exception() {
+      var validator = new TestValidator();
+      validator.RuleFor(x => x.NullableInt).GreaterThanOrEqualTo(3);
 
-			var validator = new UnitOfMeasureValidator();
+      var result = validator.TestValidate(new Person() {
+        NullableInt = 1
+      });
 
-			validator.ShouldHaveValidationErrorFor(unit => unit.Type, unitOfMeasure);
-		}
+      var ex = Assert.Throws<ValidationTestException>(() => result.ShouldHaveValidationErrorFor(x => x.NullableInt.Value));
+      Assert.Equal("Expected a validation error for property NullableInt.Value. Found 1 error for the properties: NullableInt.", ex.Message);
+    }
 
-		[Fact]
+    [Fact]
+    public void ShouldHaveValidationError_with_an_unmatched_rule_and_multiple_errors_should_throw_an_exception() {
+      var validator = new TestValidator();
+      validator.RuleFor(x => x.NullableInt).GreaterThan(1);
+      validator.RuleFor(x => x.Age).GreaterThan(1);
+      validator.RuleFor(x => x.AnotherInt).GreaterThan(2);
+
+      var result = validator.TestValidate(new Person() {
+        NullableInt = 1,
+        Age = 1,
+        AnotherInt = 1
+      });
+
+      var ex = Assert.Throws<ValidationTestException>(() => result.ShouldHaveValidationErrorFor(x => x.NullableInt.Value));
+      Assert.Equal("Expected a validation error for property NullableInt.Value. Found 3 errors for the properties: NullableInt, Age, AnotherInt.", ex.Message);
+    }
+
+    [Fact]
 		public void ShouldNotHaveValidationError_should_correctly_handle_explicitly_providing_object_to_validate() {
 			var unitOfMeasure = new UnitOfMeasure {
 				Value = 1,

--- a/src/FluentValidation/TestHelper/ValidatorTestExtensions.cs
+++ b/src/FluentValidation/TestHelper/ValidatorTestExtensions.cs
@@ -142,28 +142,34 @@ namespace FluentValidation.TestHelper {
 			return defaultMessage;
 		}
 
-		internal static IEnumerable<ValidationFailure> ShouldHaveValidationError(IList<ValidationFailure> errors, string propertyName) {
-			var failures = errors.Where(x => NormalizePropertyName(x.PropertyName) == propertyName
-			                                 || (string.IsNullOrEmpty(x.PropertyName) && string.IsNullOrEmpty(propertyName))
-			                                 || propertyName == MatchAnyFailure
-			                                 ).ToArray();
+    internal static IEnumerable<ValidationFailure> ShouldHaveValidationError(IList<ValidationFailure> errors, string propertyName) {
+      var failures = errors.Where(x => NormalizePropertyName(x.PropertyName) == propertyName
+                                       || (string.IsNullOrEmpty(x.PropertyName) && string.IsNullOrEmpty(propertyName))
+                                       || propertyName == MatchAnyFailure
+                                       ).ToArray();
 
-      if (!failures.Any()) {
-        string errorPropertiesText = string.Empty;
-
-        // If we have some errors, then lets grab the properties that errored.
-        if (errors.Any()) {
-          var errorProperties = string.Join(", ", errors.Select(x => x.PropertyName));
-          errorPropertiesText = $". Found {errors.Count} error{(errors.Count == 1 ? string.Empty : "s")} for the properties: {errorProperties}.";
-        }
-
-        var errorMessage = $"Expected a validation error for property {propertyName}{errorPropertiesText}";
-
-        throw new ValidationTestException(errorMessage);
+      if (failures.Any()) {
+        return failures;
       }
 
-			return failures;
-		}
+      // We expected an error but failed to match it.
+      var errorMessageBanner = $"Expected a validation error for property {propertyName}";
+
+      string errorMessage = "";
+
+      if (errors?.Any() == true) {
+        string errorMessageDetails = "";
+        for (int i = 0; i < errors.Count; i++) {
+          errorMessageDetails += $"[{i}]: {errors[i].PropertyName}\n";
+        }
+        errorMessage = $"{errorMessageBanner}\n----\nProperties with Validation Errors:\n{errorMessageDetails}";
+      }
+      else {
+        errorMessage = $"{errorMessageBanner}";
+      }
+
+      throw new ValidationTestException(errorMessage);
+    }
 
 		internal static void ShouldNotHaveValidationError(IEnumerable<ValidationFailure> errors, string propertyName) {
 			var failures = errors.Where(x => NormalizePropertyName(x.PropertyName) == propertyName

--- a/src/FluentValidation/TestHelper/ValidatorTestExtensions.cs
+++ b/src/FluentValidation/TestHelper/ValidatorTestExtensions.cs
@@ -149,8 +149,16 @@ namespace FluentValidation.TestHelper {
 			                                 ).ToArray();
 
       if (!failures.Any()) {
-        var errorProperties = string.Join(", ", errors.Select(x => x.PropertyName));
-        var errorMessage = $"Expected a validation error for property {propertyName}. Found {errors.Count} error{(errors.Count == 1 ? string.Empty : "s")} with the properties: {errorProperties}.";
+        string errorPropertiesText = string.Empty;
+
+        // If we have some errors, then lets grab the properties that errored.
+        if (errors.Any()) {
+          var errorProperties = string.Join(", ", errors.Select(x => x.PropertyName));
+          errorPropertiesText = $". Found {errors.Count} error{(errors.Count == 1 ? string.Empty : "s")} for the properties: {errorProperties}.";
+        }
+
+        var errorMessage = $"Expected a validation error for property {propertyName}{errorPropertiesText}";
+
         throw new ValidationTestException(errorMessage);
       }
 

--- a/src/FluentValidation/TestHelper/ValidatorTestExtensions.cs
+++ b/src/FluentValidation/TestHelper/ValidatorTestExtensions.cs
@@ -142,14 +142,17 @@ namespace FluentValidation.TestHelper {
 			return defaultMessage;
 		}
 
-		internal static IEnumerable<ValidationFailure> ShouldHaveValidationError(IEnumerable<ValidationFailure> errors, string propertyName) {
+		internal static IEnumerable<ValidationFailure> ShouldHaveValidationError(IList<ValidationFailure> errors, string propertyName) {
 			var failures = errors.Where(x => NormalizePropertyName(x.PropertyName) == propertyName
 			                                 || (string.IsNullOrEmpty(x.PropertyName) && string.IsNullOrEmpty(propertyName))
 			                                 || propertyName == MatchAnyFailure
 			                                 ).ToArray();
 
-			if (!failures.Any())
-				throw new ValidationTestException($"Expected a validation error for property {propertyName}");
+      if (!failures.Any()) {
+        var errorProperties = string.Join(", ", errors.Select(x => x.PropertyName));
+        var errorMessage = $"Expected a validation error for property {propertyName}. Found {errors.Count} error{(errors.Count == 1 ? string.Empty : "s")} with the properties: {errorProperties}.";
+        throw new ValidationTestException(errorMessage);
+      }
 
 			return failures;
 		}


### PR DESCRIPTION
In #1220 I pointed out that there's a weird issue when trying to test validation rules against a `Nullable` type. Took me ages to figure out because I didn't think it was a bug with FV and only when I finally stepped through the code, did I figure out that there is an issue in FV.

This could have been mitigated _quicker_ if there was some nicer error messages. As such, I've added some more error message stuff, here.

This doesn't fix #1220 but it helps speed up time, creating tests to circumnavigate this issue.