### PR TITLE
Added inheritance validation

### DIFF
--- a/src/FluentValidation.Tests/InheritanceValidatorExtensionTests.cs
+++ b/src/FluentValidation.Tests/InheritanceValidatorExtensionTests.cs
@@ -1,0 +1,28 @@
+﻿namespace FluentValidation.Tests {
+  using System.Linq;
+  using Internal;
+  using Validators;
+  using Xunit;
+
+  public class InheritanceValidatorExtensionTests {
+
+
+    private readonly AbstractValidator<Person> _validator;
+
+    public InheritanceValidatorExtensionTests() {
+      _validator = new TestValidator();
+    }
+     
+    [Fact]
+    public void AddInheritance_should_create_InheritanceValidator() {
+      _validator.RuleFor(x => x.Vehicle).AddInheritance(inheritance => { });
+
+      var rule = (PropertyRule)_validator.First();
+      var validator = (ChildValidatorAdaptor)rule.CurrentValidator;
+      validator.ValidatorType.ShouldEqual(typeof(InheritanceValidator<IVehicle>));
+
+    }
+     
+    
+  }
+}

--- a/src/FluentValidation.Tests/InheritanceValidatorTests.cs
+++ b/src/FluentValidation.Tests/InheritanceValidatorTests.cs
@@ -1,0 +1,139 @@
+﻿namespace FluentValidation.Tests {
+  using System;
+  using System.Collections.Generic;
+  using Xunit;
+
+  public class InheritanceValidatorTests {
+
+
+    [Fact]
+    public void InheritanceValidator_should_pass_if_bike_hasbell_is_true() {
+
+      var validator = new TestValidator(v => {
+        v.RuleFor(x => x.Vehicle).AddInheritance(i => {
+          i.Include<Car>(b => { b.RuleFor(m => m.IsElectric).Must(x => x); });
+          i.Include<Bike>(b => { b.RuleFor(m => m.HasBell).Must(x => x); });
+        });
+      });
+
+      var result = validator.Validate(new Person { Vehicle = new Bike() { HasBell = true } });
+      result.IsValid.ShouldBeTrue();
+
+    }
+
+    [Fact]
+    public void InheritanceValidator_should_pass_if_bike_hasbell_is_true_and_title_is_notnull() {
+
+      var validator = new TestValidator(v => {
+        v.RuleFor(x => x.Vehicle.Title).NotNull();
+        v.RuleFor(x => x.Vehicle).AddInheritance(i => {
+          i.Include<Car>(b => { b.RuleFor(m => m.IsElectric).Must(x => x); });
+          i.Include<Bike>(b => { b.RuleFor(m => m.HasBell).Must(x => x); });
+        });
+      });
+
+      var result = validator.Validate(new Person { Vehicle = new Bike() { HasBell = true, Title = "My awesome bike" } });
+      result.IsValid.ShouldBeTrue();
+
+    }
+
+    [Fact]
+    public void InheritanceValidator_should_fail_if_bike_hasbell_is_true_and_title_is_null() {
+
+      var validator = new TestValidator(v => {
+        v.RuleFor(x => x.Vehicle.Title).NotNull();
+        v.RuleFor(x => x.Vehicle).AddInheritance(i => {
+          i.Include<Car>(b => { b.RuleFor(m => m.IsElectric).Must(x => x); });
+          i.Include<Bike>(b => { b.RuleFor(m => m.HasBell).Must(x => x); });
+        });
+      });
+
+      var result = validator.Validate(new Person { Vehicle = new Bike() { HasBell = true } });
+      result.IsValid.ShouldBeFalse();
+
+    }
+
+
+    [Fact]
+    public void InheritanceValidator_should_pass_if_car_iselectric_is_true() {
+
+      var validator = new TestValidator(v => {
+        v.RuleFor(x => x.Vehicle).AddInheritance(i => {
+          i.Include<Car>(b => { b.RuleFor(m => m.IsElectric).Must(x => x); });
+          i.Include<Bike>(b => { b.RuleFor(m => m.HasBell).Must(x => x); });
+        });
+      });
+
+      var result = validator.Validate(new Person { Vehicle = new Car() { IsElectric = true } });
+
+      result.IsValid.ShouldBeTrue();
+
+    }
+
+    [Fact]
+    public void InheritanceValidator_should_fail_if_car_iselectric_is_false() {
+
+      var validator = new TestValidator(v => {
+        v.RuleFor(x => x.Vehicle).AddInheritance(i => {
+          i.Include<Car>(b => { b.RuleFor(m => m.IsElectric).Must(x => x); });
+          i.Include<Bike>(b => { b.RuleFor(m => m.HasBell).Must(x => x); });
+        });
+      });
+
+      var result = validator.Validate(new Person { Vehicle = new Car() });
+
+      result.IsValid.ShouldBeFalse();
+
+    }
+
+
+    [Fact]
+    public void InheritanceValidator_should_pass_without_inlinevalidator_if_bike_hasbell_is_true() {
+
+      var validator = new TestValidator(v => {
+        v.RuleFor(x => x.Vehicle).AddInheritance(i => {
+          i.Include<Car>(b => { b.RuleFor(m => m.IsElectric).Must(x => x); });
+          i.Include<Bike>(new BikeTestValidator(m => m.RuleFor(z => z.HasBell).Must(x => x)));
+        });
+      });
+
+      var result = validator.Validate(new Person { Vehicle = new Bike() { HasBell = true } });
+
+      result.IsValid.ShouldBeTrue();
+
+    }
+
+    [Fact]
+    public void InheritanceValidator_should_pass_if_list_wantedvehicles_passed_conditions() {
+
+
+
+      var validator = new TestValidator(v => {
+        v.RuleForEach(x => x.WantedVehicles).AddInheritance(i => {
+          i.Include<Car>(b => { b.RuleFor(m => m.IsElectric).Must(x => x); });
+          i.Include<Bike>(b => { b.RuleFor(m => m.HasBell).Must(x => x); });
+        });
+      }); 
+
+      var result = validator.Validate(new Person { WantedVehicles = new List<IVehicle>() {
+        new Car() { IsElectric = true },
+        new Bike() { HasBell = true }
+      } });
+
+      result.IsValid.ShouldBeTrue();
+
+    }
+    public class BikeTestValidator : InlineValidator<Bike> {
+      public BikeTestValidator() {
+
+      } 
+
+      public BikeTestValidator(params Action<BikeTestValidator>[] actions) {
+        foreach (var action in actions) {
+          action(this);
+        }
+      }
+    }
+
+  }
+}

--- a/src/FluentValidation.Tests/Person.cs
+++ b/src/FluentValidation.Tests/Person.cs
@@ -16,99 +16,121 @@
 // The latest version of this file can be found at https://github.com/jeremyskinner/FluentValidation
 #endregion
 
-namespace FluentValidation.Tests
-{
-	using System;
-	using System.Collections.Generic;
-	using Attributes;
+namespace FluentValidation.Tests {
+  using System;
+  using System.Collections.Generic;
+  using Attributes;
 
-	[Validator(typeof(TestValidator))]
-	public class Person {
-		public string NameField;
-		public int Id { get; set; }
-		public string Surname { get; set; }
-		public string Forename { get; set; }
+  [Validator(typeof(TestValidator))]
+  public class Person {
+    public string NameField;
+    public int Id { get; set; }
+    public string Surname { get; set; }
+    public string Forename { get; set; }
 
-		public List<Person> Children { get; set; }
-		public string[] NickNames { get; set; }
+    public List<Person> Children { get; set; }
+    public string[] NickNames { get; set; }
 
-		public DateTime DateOfBirth { get; set; }
+    public DateTime DateOfBirth { get; set; }
 
-		public int? NullableInt { get; set; }
+    public int? NullableInt { get; set; }
 
-		public Person() {
-			Children = new List<Person>();
-			Orders = new List<Order>();
-		}
-
-		public int CalculateSalary() {
-			return 20;
-		}
-
-		public Address Address { get; set; }
-		public IList<Order> Orders { get; set; }
-
-		public string Email { get; set; }
-		public decimal Discount { get; set; }
-		public double Age { get; set; }
-
-		public int AnotherInt { get; set; }
-
-		public string CreditCard { get; set; }
-
-		public int? OtherNullableInt { get; set; }
-
-		public string Regex { get; set; }
-
-		public System.Text.RegularExpressions.Regex AnotherRegex { get; set; }
-
-		public int MinLength { get; set; }
-
-		public int MaxLength { get; set; }
-
-        public EnumGender Gender { get; set; }
-
-		public string GenderString { get; set; }
-
-		public string ForenameReadOnly => Forename;
-	}
-
-
-	public interface IAddress {
-		string Line1 { get; set; }
-		string Line2 { get; set; }
-		string Town { get; set; }
-		string County { get; set; }
-		string Postcode { get; set; }
-		Country Country { get; set; }
-	}
-
-	public class Address : IAddress {
-		public string Line1 { get; set; }
-		public string Line2 { get; set; }
-		public string Town { get; set; }
-		public string County { get; set; }
-		public string Postcode { get; set; }
-		public Country Country { get; set; }
-		public int Id { get; set; }
-	}
-
-	public class Country {
-		public string Name { get; set; }
-	}
-
-	public interface IOrder {
-		decimal Amount { get; }
-	}
-
-	public class Order : IOrder {
-		public string ProductName { get; set; }
-		public decimal Amount { get; set; }
-	}
-
-    public enum EnumGender
-    {
-        Female = 1,
-        Male = 2
+    public Person() {
+      Children = new List<Person>();
+      Orders = new List<Order>();
+      WantedVehicles = new List<IVehicle>();
     }
+
+    public int CalculateSalary() {
+      return 20;
+    }
+
+    public Address Address { get; set; }
+    public IList<Order> Orders { get; set; }
+
+    public string Email { get; set; }
+    public decimal Discount { get; set; }
+    public double Age { get; set; }
+
+    public int AnotherInt { get; set; }
+
+    public string CreditCard { get; set; }
+
+    public int? OtherNullableInt { get; set; }
+
+    public string Regex { get; set; }
+
+    public System.Text.RegularExpressions.Regex AnotherRegex { get; set; }
+
+    public int MinLength { get; set; }
+
+    public int MaxLength { get; set; }
+
+    public EnumGender Gender { get; set; }
+
+    public string GenderString { get; set; }
+     
+    public IVehicle Vehicle { get; set; }
+
+    public List<IVehicle> WantedVehicles { get; set; }
+
+    public string ForenameReadOnly => Forename;
+
+  } 
+
+  public interface IVehicle {
+    string Title { get; set; }
+  }
+
+  public class Car : IVehicle {
+     
+    public string Title { get; set; }
+       
+    public bool IsElectric { get; set; }
+
+  }
+
+  public class Bike : IVehicle {
+
+    public bool HasBell { get; set; }
+    public string Title { get; set; }
+
+  }
+
+  public interface IAddress {
+    string Line1 { get; set; }
+    string Line2 { get; set; }
+    string Town { get; set; }
+    string County { get; set; }
+    string Postcode { get; set; }
+    Country Country { get; set; }
+  }
+
+  public class Address : IAddress {
+    public string Line1 { get; set; }
+    public string Line2 { get; set; }
+    public string Town { get; set; }
+    public string County { get; set; }
+    public string Postcode { get; set; }
+    public Country Country { get; set; }
+    public int Id { get; set; }
+  }
+
+  public class Country {
+    public string Name { get; set; }
+  }
+
+  public interface IOrder {
+    decimal Amount { get; }
+  }
+
+  public class Order : IOrder {
+    public string ProductName { get; set; }
+    public decimal Amount { get; set; }
+  }
+
+  public enum EnumGender {
+    Female = 1,
+    Male = 2
+  }
 }

--- a/src/FluentValidation/InheritanceValidatorExtensions.cs
+++ b/src/FluentValidation/InheritanceValidatorExtensions.cs
@@ -1,0 +1,26 @@
+﻿
+
+namespace FluentValidation {
+  using Validators;
+  using System;
+  using System.Collections.Generic;
+
+  public static class InheritanceValidatorExtensions {
+
+    /// <summary>
+    /// Add validator(s) for the derived types for this model
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <typeparam name="TProperty"></typeparam>
+    /// <param name="ruleBuilder"></param>
+    /// <param name="builder"></param>
+    /// <returns></returns>
+    public static IRuleBuilderOptions<T, TProperty> AddInheritance<T, TProperty>(this IRuleBuilder<T, TProperty> ruleBuilder, Action<IDerivedValidatorBuilder<TProperty>> builder) where TProperty : class {
+      var inheritanceValidator = new InheritanceValidator<TProperty>();
+      builder(inheritanceValidator);
+      return ruleBuilder.SetValidator(inheritanceValidator);
+    }
+
+
+  }
+}

--- a/src/FluentValidation/Validators/IDerivedValidatorBuilder.cs
+++ b/src/FluentValidation/Validators/IDerivedValidatorBuilder.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace FluentValidation.Validators {
+  public interface IDerivedValidatorBuilder<in T> where T : class {
+
+    void Include<TDerived>(Action<InlineValidator<TDerived>> builder) where TDerived : class, T;
+
+    void Include<TDerived>(IValidator<TDerived> validator) where TDerived : class, T;
+
+  } 
+}

--- a/src/FluentValidation/Validators/InheritanceValidator.cs
+++ b/src/FluentValidation/Validators/InheritanceValidator.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentValidation.Results;
+
+namespace FluentValidation.Validators {
+
+  public class InheritanceValidator<T> : AbstractValidator<T>, IDerivedValidatorBuilder<T> where T : class {
+
+    private readonly Dictionary<Type, IValidator> _derivedValidators;
+
+    internal InheritanceValidator() {
+      _derivedValidators = new Dictionary<Type, IValidator>();
+    }
+
+    /// <summary>
+    /// Define a validator for a derived class
+    /// </summary>
+    /// <typeparam name="TDerived"></typeparam>
+    /// <param name="builder"></param>
+    public void Include<TDerived>(Action<InlineValidator<TDerived>> builder) where TDerived : class, T {
+      var validator = new InlineValidator<TDerived>();
+      builder(validator);
+      Include(validator);
+    }
+
+    /// <summary>
+    /// Define a validator for a derived class
+    /// </summary>
+    /// <typeparam name="TDerived"></typeparam>
+    /// <param name="validator"></param>
+    public void Include<TDerived>(IValidator<TDerived> validator) where TDerived : class, T {
+      _derivedValidators[typeof(TDerived)] = validator;
+    }
+
+    public override Task<ValidationResult> ValidateAsync(ValidationContext<T> context, CancellationToken cancellation = new CancellationToken()) {
+      var validator = Get(context.InstanceToValidate.GetType());
+
+      if (validator == null)
+        return base.ValidateAsync(context, cancellation);
+
+      return validator.ValidateAsync(context, cancellation);
+    }
+
+    public override ValidationResult Validate(ValidationContext<T> context) {
+
+      var validator = Get(context.InstanceToValidate.GetType());
+
+      if (validator == null)
+        return base.Validate(context);
+
+      return Get(context.InstanceToValidate.GetType()).Validate(context);
+    }
+
+    protected override bool PreValidate(ValidationContext<T> context, ValidationResult result) {
+
+      var validator = Get(context.InstanceToValidate.GetType());
+
+      if (validator == null)
+        return base.PreValidate(context, result);
+
+      return base.PreValidate(context, result);
+    }
+
+    private IValidator Get(Type type) {
+      return !_derivedValidators.TryGetValue(type, out var validator) ? null : validator;
+    }
+
+  } 
+}


### PR DESCRIPTION
Added validation option for derived class in a class.

Example:

```
var validator = new TestValidator(v => {
  v.RuleFor(x => x.Vehicle.Title).NotNull();
  v.RuleFor(x => x.Vehicle).AddInheritance(i => {
    i.Include<Car>(b => { b.RuleFor(m => m.IsElectric).Must(x => x); });
    i.Include<Bike>(b => { b.RuleFor(m => m.HasBell).Must(x => x); });
  });
});

validator.Validate(new Person { Vehicle = new Bike() { HasBell = true, Title = "My awesome bike" } });

public class Person {

  (...)

  public IVehicle Vehicle { get; set; }

}

public interface IVehicle {
  string Title { get; set; }
}

public class Car : IVehicle {
  public string Title { get; set; }
  public bool IsElectric { get; set; }
}

public class Bike : IVehicle {
  public bool HasBell { get; set; }
  public string Title { get; set; }
}
```