### PR TITLE
Open generics registration

### DIFF
--- a/src/FluentValidation.DependencyInjectionExtensions/ServiceCollectionExtensions.cs
+++ b/src/FluentValidation.DependencyInjectionExtensions/ServiceCollectionExtensions.cs
@@ -79,12 +79,14 @@ namespace FluentValidation {
 		/// <param name="lifetime">The lifetime of the validators. The default is transient</param>
 		/// <returns></returns>
 		private static IServiceCollection AddScanResult(this IServiceCollection services, AssemblyScanner.AssemblyScanResult scanResult, ServiceLifetime lifetime) {
-			//Register as interface
-			services.Add(
-				new ServiceDescriptor(
-							serviceType: scanResult.InterfaceType,
-							implementationType: scanResult.ValidatorType,
-							lifetime: lifetime));
+      //Register as interface
+      if (!scanResult.ValidatorType.IsGenericTypeDefinition) {
+        services.Add(
+            new ServiceDescriptor(
+                  serviceType: scanResult.InterfaceType,
+                  implementationType: scanResult.ValidatorType,
+                  lifetime: lifetime)); 
+      }
 
 			//Register as self
 			services.Add(

--- a/src/FluentValidation/AssemblyScanner.cs
+++ b/src/FluentValidation/AssemblyScanner.cs
@@ -81,7 +81,7 @@ namespace FluentValidation {
 
 #if NETSTANDARD1_1 || NETSTANDARD1_6
 			var query = from type in _types
-				where !type.GetTypeInfo().IsAbstract && !type.GetTypeInfo().IsGenericTypeDefinition
+				where !type.GetTypeInfo().IsAbstract
 				let interfaces = type.GetTypeInfo().ImplementedInterfaces
 				let genericInterfaces = interfaces.Where(i => i.GetTypeInfo().IsGenericType && i.GetGenericTypeDefinition() == openGenericType)
 				let matchingInterface = genericInterfaces.FirstOrDefault()
@@ -89,7 +89,7 @@ namespace FluentValidation {
 				select new AssemblyScanResult(matchingInterface, type);
 #else
 			var query = from type in _types
-						where !type.IsAbstract && !type.IsGenericTypeDefinition
+						where !type.IsAbstract 
 						let interfaces = type.GetInterfaces()
 						let genericInterfaces = interfaces.Where(i => i.GetTypeInfo().IsGenericType && i.GetGenericTypeDefinition() == openGenericType)
 						let matchingInterface = genericInterfaces.FirstOrDefault()


### PR DESCRIPTION
PR for #1286 
Well, I took a glance through source code and found out that FluentValidation takes care of registration. Therefore it could be its responsibility to handle open generics, as it does with regular types through `.AddFluentValidation(fv => fv.RegisterValidatorsFromAssemblyContaining<Startup>())` extension. Said that, I made some changes to the `FluentValidation` and `FluentValidation.DependencyInjectionExtension` projects and seems like it does a trick. The only thing I need is check and verify if these changes are valid, because I didn't have a much time to check everything out and honestly it is a first time a looked at source code. Thanks)